### PR TITLE
[SC-25]: Calculate T1, T2 Energy values

### DIFF
--- a/src/lightControl/01-config.ino.example
+++ b/src/lightControl/01-config.ino.example
@@ -7,6 +7,8 @@
 #define POST_PZEM_ENDPOINT "pzem-server-endpoint-url"
 #define POST_PZEM_INTERVAL 1000
 
+#define TIMEZONE_OFFSET 0
+
 // GPIO pins
 #define PZEM_RX_PIN 1
 #define PZEM_TX_PIN 2

--- a/src/lightControl/03-pzem.ino
+++ b/src/lightControl/03-pzem.ino
@@ -1,6 +1,7 @@
 SoftwareSerial pzemSerial(PZEM_TX_PIN, PZEM_RX_PIN);
 PZEM004Tv30 pzem(pzemSerial);
 
+
 JsonDocument getPzemValues() {
   JsonDocument doc;
 

--- a/src/lightControl/03-pzem.ino
+++ b/src/lightControl/03-pzem.ino
@@ -1,30 +1,162 @@
 SoftwareSerial pzemSerial(PZEM_TX_PIN, PZEM_RX_PIN);
 PZEM004Tv30 pzem(pzemSerial);
 
+float t1StartEnergy = 0;
+float t2StartEnergy = 0;
+float t1EnergyAcc = 0;
+float t2EnergyAcc = 0;
 
-JsonDocument getPzemValues() {
-  JsonDocument doc;
+Pzem getPzemValues() {
+  Pzem sensor;
 
-  doc["voltageV"] = pzem.voltage();
-  doc["currentA"] = pzem.current();
-  doc["powerKw"] = pzem.power() / 1000.0;
-  doc["energyKwh"] = pzem.energy();
-  doc["frequencyHz"] = pzem.frequency();
-  doc["powerFactor"] = pzem.pf();
+  sensor.voltage = pzem.voltage();
+  sensor.createdAt = getDate();
 
-  doc["creationTimeGmt"] = getISODateTimeString();
+  if (isnan(sensor.voltage)) {
+    sensor.current = NAN;
+    sensor.power = NAN;
+    sensor.energy = NAN;
+    sensor.frequency = NAN;
+    sensor.powerFactor = NAN;
+    sensor.t1Energy = NAN;
+    sensor.t2Energy = NAN;
+  } else {
+    sensor.current = pzem.current();
+    sensor.power = pzem.power() / 1000.0;
+    sensor.energy = pzem.energy();
+    sensor.frequency = pzem.frequency();
+    sensor.powerFactor = pzem.pf();
 
-  return doc;
+    calcZonedEnergy(sensor);
+  }
+
+  return sensor;
 }
 
-String getJsonPzemValues() {
+String pzemToJson(Pzem sensor) {
+  JsonDocument doc;
   String result;
 
-  serializeJson(getPzemValues(), result);
+  doc["voltageV"] = sensor.voltage;
+  doc["currentA"] = sensor.current;
+  doc["powerKw"] = sensor.power;
+  doc["energyKwh"] = sensor.energy;
+  doc["frequencyHz"] = sensor.frequency;
+  doc["powerFactor"] = sensor.powerFactor;
+  doc["t1EnergyKwh"] = sensor.t1Energy;
+  doc["t2EnergyKwh"] = sensor.t2Energy;
+  doc["createdAt"] = toISODateString(sensor.createdAt);
+
+  serializeJson(doc, result);
 
   return result;
 }
 
 void resetEnergyCounter() {
   pzem.resetEnergy();
+}
+
+void calcZonedEnergy(Pzem &sensor) {
+  float t1Energy;
+  float t2Energy;
+
+  Serial.print(F("Current day: "));
+  Serial.println(sensor.createdAt.day);
+  Serial.print(F("Current hour: "));
+  Serial.println(sensor.createdAt.hour);
+  Serial.print(F("Current minute: "));
+  Serial.println(sensor.createdAt.minute);
+  Serial.print(F("Current second: "));
+  Serial.println(sensor.createdAt.second);
+
+  if (isT1ZoneActive(sensor.createdAt.hour)) {
+    Serial.println(F("Active zone is T1"));
+
+    t1Energy = calcT1ZoneEnergy(sensor);
+    t2Energy = t2EnergyAcc;
+
+    Serial.print(F("Calculated T1: "));
+    Serial.println(t1Energy);
+    Serial.print(F("T2 Acc value: "));
+    Serial.println(t2EnergyAcc);
+  } else {
+    Serial.println(F("Active zone is T2"));
+
+    t1Energy = t1EnergyAcc;
+    t2Energy = calcT2ZoneEnergy(sensor);
+
+    Serial.print(F("T1 Acc value: "));
+    Serial.println(t1EnergyAcc);
+    Serial.print(F("Calculated T2: "));
+    Serial.println(t2Energy);
+  }
+
+  Serial.println(F("---- After calculation ----"));
+  Serial.print(F("Calculated T1 energy: "));
+  Serial.println(t1Energy);
+  Serial.print(F("Calculated T2 energy: "));
+  Serial.println(t2Energy);
+
+  sensor.t1Energy = t1Energy;
+  sensor.t2Energy = t2Energy;
+}
+
+float calcT1ZoneEnergy(Pzem sensor) {
+  bool isStartOfZone = isStartOfT1Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
+  bool isEndOfZone = isEndOfT1Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
+
+  Serial.print(F("T1: isStartOfZone predicate: "));
+  Serial.println(isStartOfZone);
+  Serial.print(F("T1: isEndOfZone predicate: "));
+  Serial.println(isEndOfZone);
+
+  if (!t1StartEnergy || isStartOfZone) {
+    t1StartEnergy = sensor.energy;
+  }
+
+  float t1Energy = sensor.energy - t1StartEnergy + t1EnergyAcc;
+
+  Serial.println(F("T1: Operands"));
+  Serial.print(F("T1: current energy: "));
+  Serial.println(sensor.energy);
+  Serial.print(F("T1: t1StartEnergy: "));
+  Serial.println(t1StartEnergy);
+  Serial.print(F("T1: t1EnergyAcc: "));
+  Serial.println(t1EnergyAcc);
+
+  if (isEndOfZone) {
+    t1EnergyAcc = t1Energy;
+  }
+
+  return t1Energy;
+}
+
+float calcT2ZoneEnergy(Pzem sensor) {
+  bool isStartOfZone = isStartOfT2Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
+  bool isEndOfZone = isEndOfT2Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
+
+  Serial.print(F("T2: isStartOfZone predicate: "));
+  Serial.println(isStartOfZone);
+  Serial.print(F("T2: isEndOfZone predicate: "));
+  Serial.println(isEndOfZone);
+
+  if (!t2StartEnergy || isStartOfZone) {
+    t2StartEnergy = sensor.energy;
+  }
+
+  float t2Energy = sensor.energy - t2StartEnergy + t2EnergyAcc;
+
+  Serial.println(F("T1: Operands"));
+  Serial.print(F("T2: current energy: "));
+  Serial.println(sensor.energy);
+  Serial.print(F("T2: t2StartEnergy: "));
+  Serial.println(t2StartEnergy);
+  Serial.print(F("T2: t2EnergyAcc: "));
+  Serial.println(t2EnergyAcc);
+
+  if (isEndOfZone) {
+    t2EnergyAcc = t2Energy;
+  }
+
+  return t2Energy;
 }

--- a/src/lightControl/03-pzem.ino
+++ b/src/lightControl/03-pzem.ino
@@ -1,10 +1,10 @@
 SoftwareSerial pzemSerial(PZEM_TX_PIN, PZEM_RX_PIN);
 PZEM004Tv30 pzem(pzemSerial);
 
-float t1StartEnergy = 0;
-float t2StartEnergy = 0;
-float t1EnergyAcc = 0;
-float t2EnergyAcc = 0;
+float t1StartEnergy = 0.0;
+float t2StartEnergy = 0.0;
+float t1EnergyAcc = 0.0;
+float t2EnergyAcc = 0.0;
 
 Pzem getPzemValues() {
   Pzem sensor;
@@ -27,7 +27,7 @@ Pzem getPzemValues() {
     sensor.frequency = pzem.frequency();
     sensor.powerFactor = pzem.pf();
 
-    calcZonedEnergy(sensor);
+    calcZoneEnergy(sensor);
   }
 
   return sensor;
@@ -54,48 +54,24 @@ String pzemToJson(Pzem sensor) {
 
 void resetEnergyCounter() {
   pzem.resetEnergy();
+
+  t1StartEnergy = 0.0;
+  t2StartEnergy = 0.0;
+  t1EnergyAcc = 0.0;
+  t2EnergyAcc = 0.0;
 }
 
-void calcZonedEnergy(Pzem &sensor) {
+void calcZoneEnergy(Pzem &sensor) {
   float t1Energy;
   float t2Energy;
 
-  Serial.print(F("Current day: "));
-  Serial.println(sensor.createdAt.day);
-  Serial.print(F("Current hour: "));
-  Serial.println(sensor.createdAt.hour);
-  Serial.print(F("Current minute: "));
-  Serial.println(sensor.createdAt.minute);
-  Serial.print(F("Current second: "));
-  Serial.println(sensor.createdAt.second);
-
   if (isT1ZoneActive(sensor.createdAt.hour)) {
-    Serial.println(F("Active zone is T1"));
-
     t1Energy = calcT1ZoneEnergy(sensor);
     t2Energy = t2EnergyAcc;
-
-    Serial.print(F("Calculated T1: "));
-    Serial.println(t1Energy);
-    Serial.print(F("T2 Acc value: "));
-    Serial.println(t2EnergyAcc);
   } else {
-    Serial.println(F("Active zone is T2"));
-
     t1Energy = t1EnergyAcc;
     t2Energy = calcT2ZoneEnergy(sensor);
-
-    Serial.print(F("T1 Acc value: "));
-    Serial.println(t1EnergyAcc);
-    Serial.print(F("Calculated T2: "));
-    Serial.println(t2Energy);
   }
-
-  Serial.println(F("---- After calculation ----"));
-  Serial.print(F("Calculated T1 energy: "));
-  Serial.println(t1Energy);
-  Serial.print(F("Calculated T2 energy: "));
-  Serial.println(t2Energy);
 
   sensor.t1Energy = t1Energy;
   sensor.t2Energy = t2Energy;
@@ -105,24 +81,11 @@ float calcT1ZoneEnergy(Pzem sensor) {
   bool isStartOfZone = isStartOfT1Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
   bool isEndOfZone = isEndOfT1Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
 
-  Serial.print(F("T1: isStartOfZone predicate: "));
-  Serial.println(isStartOfZone);
-  Serial.print(F("T1: isEndOfZone predicate: "));
-  Serial.println(isEndOfZone);
-
   if (!t1StartEnergy || isStartOfZone) {
     t1StartEnergy = sensor.energy;
   }
 
   float t1Energy = sensor.energy - t1StartEnergy + t1EnergyAcc;
-
-  Serial.println(F("T1: Operands"));
-  Serial.print(F("T1: current energy: "));
-  Serial.println(sensor.energy);
-  Serial.print(F("T1: t1StartEnergy: "));
-  Serial.println(t1StartEnergy);
-  Serial.print(F("T1: t1EnergyAcc: "));
-  Serial.println(t1EnergyAcc);
 
   if (isEndOfZone) {
     t1EnergyAcc = t1Energy;
@@ -135,24 +98,11 @@ float calcT2ZoneEnergy(Pzem sensor) {
   bool isStartOfZone = isStartOfT2Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
   bool isEndOfZone = isEndOfT2Zone(sensor.createdAt.hour, sensor.createdAt.minute, sensor.createdAt.second);
 
-  Serial.print(F("T2: isStartOfZone predicate: "));
-  Serial.println(isStartOfZone);
-  Serial.print(F("T2: isEndOfZone predicate: "));
-  Serial.println(isEndOfZone);
-
   if (!t2StartEnergy || isStartOfZone) {
     t2StartEnergy = sensor.energy;
   }
 
   float t2Energy = sensor.energy - t2StartEnergy + t2EnergyAcc;
-
-  Serial.println(F("T1: Operands"));
-  Serial.print(F("T2: current energy: "));
-  Serial.println(sensor.energy);
-  Serial.print(F("T2: t2StartEnergy: "));
-  Serial.println(t2StartEnergy);
-  Serial.print(F("T2: t2EnergyAcc: "));
-  Serial.println(t2EnergyAcc);
 
   if (isEndOfZone) {
     t2EnergyAcc = t2Energy;

--- a/src/lightControl/04-server.ino
+++ b/src/lightControl/04-server.ino
@@ -34,7 +34,7 @@ void configRouter() {
 void handleRoot() {
   digitalWrite(LED_BUILTIN, LOW);
 
-  server.send(HTTP_CODE_OK, "application/json", getJsonPzemValues());
+  server.send(HTTP_CODE_OK, "application/json", pzemToJson(getPzemValues()));
 
   digitalWrite(LED_BUILTIN, HIGH);
 }

--- a/src/lightControl/05-time.ino
+++ b/src/lightControl/05-time.ino
@@ -6,7 +6,7 @@ void startNTP() {
   Serial.print(F("NTP started. Status: "));
   Serial.println(status);
 
-  if (status > 1) {
+  if (status != 0) {
     Serial.print(F("NTP Status is not ok. Updating... "));
 
     uint8_t status = updateTime();

--- a/src/lightControl/06-client.ino
+++ b/src/lightControl/06-client.ino
@@ -6,6 +6,7 @@ void streamPzemValues() {
   if (currentMillis - previousMillis >= POST_PZEM_INTERVAL) {
     previousMillis = currentMillis;
 
+    calcZoneEnergy();
     jsonPOST(POST_PZEM_ENDPOINT, getJsonPzemValues());
   }
 }

--- a/src/lightControl/06-client.ino
+++ b/src/lightControl/06-client.ino
@@ -6,8 +6,7 @@ void streamPzemValues() {
   if (currentMillis - previousMillis >= POST_PZEM_INTERVAL) {
     previousMillis = currentMillis;
 
-    calcZoneEnergy();
-    jsonPOST(POST_PZEM_ENDPOINT, getJsonPzemValues());
+    // jsonPOST(POST_PZEM_ENDPOINT, pzemToJson(getPzemValues()));
   }
 }
 

--- a/src/lightControl/06-client.ino
+++ b/src/lightControl/06-client.ino
@@ -6,7 +6,7 @@ void streamPzemValues() {
   if (currentMillis - previousMillis >= POST_PZEM_INTERVAL) {
     previousMillis = currentMillis;
 
-    // jsonPOST(POST_PZEM_ENDPOINT, pzemToJson(getPzemValues()));
+    jsonPOST(POST_PZEM_ENDPOINT, pzemToJson(getPzemValues()));
   }
 }
 

--- a/src/lightControl/lightControl.ino
+++ b/src/lightControl/lightControl.ino
@@ -5,6 +5,30 @@
 #include <GyverNTP.h>
 #include <ESP8266HTTPClient.h>
 
+struct Date {
+  uint16_t year;
+  uint8_t month;
+  uint8_t day;
+  uint8_t hour;
+  uint8_t minute;
+  uint8_t second;
+  uint16_t ms;
+};
+
+struct Pzem {
+  float voltage;
+  float current;
+  float power;
+  float energy;
+  float frequency;
+  float powerFactor;
+
+  float t1Energy;
+  float t2Energy;
+
+  Date createdAt;
+};
+
 void initLedPins() {
   pinMode(LED_BUILTIN, OUTPUT);
 }
@@ -28,5 +52,5 @@ void loop() {
   syncTime();
 
   handleClient();
-  streamPzemValues();
+  // streamPzemValues();
 }

--- a/src/lightControl/lightControl.ino
+++ b/src/lightControl/lightControl.ino
@@ -22,10 +22,8 @@ struct Pzem {
   float energy;
   float frequency;
   float powerFactor;
-
   float t1Energy;
   float t2Energy;
-
   Date createdAt;
 };
 
@@ -52,5 +50,5 @@ void loop() {
   syncTime();
 
   handleClient();
-  // streamPzemValues();
+  streamPzemValues();
 }


### PR DESCRIPTION
## Description

- Recalculate zoned energy on Arduino instead of server;
- Decrease sensor polling time when it disconnected/damaged from 648ms to 108ms
- Fix bug related to negative T1/T2 values after counter resetting
- Fix bug with time syncing via NTP. If NTP started with a non-zero status, manually send a UDP request to sync date-time.
- Checked Arduino calculation with Node.js app and Excel

Arduino:
<img width="1702" alt="Screenshot 2024-06-01 at 6 43 03 PM" src="https://github.com/AndriiKitsun/solar-control-arduino/assets/44744145/8019bb45-3f87-4b4d-b6d8-ab4cff0a3c50">
MS Excel:
<img width="1129" alt="image" src="https://github.com/AndriiKitsun/solar-control-arduino/assets/44744145/6fdd1696-ab97-4711-a083-f8d3d28c9db8">


