### PR TITLE
SC-9: Multiple AC PZEM sensors support

### DIFF
--- a/src/lightControl/01-config.ino.example
+++ b/src/lightControl/01-config.ino.example
@@ -12,3 +12,6 @@
 // GPIO pins
 #define PZEM_RX_PIN 1
 #define PZEM_TX_PIN 2
+
+#define INPUT_AC_PZEM_ADDRESS 0x01
+#define OUTPUT_AC_PZEM_ADDRESS 0x02

--- a/src/lightControl/03-pzem.ino
+++ b/src/lightControl/03-pzem.ino
@@ -99,6 +99,20 @@ float calcT2ZoneEnergy(const Pzem &sensor, Zone &zone) {
   return t2Energy;
 }
 
+String changePzemAddress(uint8_t addr) {
+  JsonDocument doc;
+  String result;
+
+  doc[F("currentAddress")] = inputAcPzem.getAddress();
+  doc[F("addressToSet")] = addr;
+  doc[F("isConnected")] = !isnan(inputAcPzem.voltage());
+  doc[F("isChanged")] = inputAcPzem.setAddress(addr);
+
+  serializeJson(doc, result);
+
+  return result;
+}
+
 void resetPzemCounter(PZEM004Tv30 &sensor, Zone &zone) {
   sensor.resetEnergy();
 
@@ -111,20 +125,6 @@ void resetPzemCounter(PZEM004Tv30 &sensor, Zone &zone) {
 void resetEnergyCounter() {
   resetPzemCounter(inputAcPzem, inputAcPzemZone);
   resetPzemCounter(outputAcPzem, outputAcPzemZone);
-}
-
-String changePzemAddress(const uint8_t &addr) {
-  JsonDocument doc;
-  String result;
-
-  doc[F("currentAddress")] = inputAcPzem.getAddress();
-  doc[F("addressToSet")] = addr;
-  doc[F("isConnected")] = !isnan(inputAcPzem.voltage());
-  doc[F("isChanged")] = inputAcPzem.setAddress(addr);
-
-  serializeJson(doc, result);
-
-  return result;
 }
 
 String collectPzemPayload() {

--- a/src/lightControl/04-server.ino
+++ b/src/lightControl/04-server.ino
@@ -24,7 +24,8 @@ void handleClient() {
 void configRouter() {
   server.on(F("/"), HTTP_GET, handleRoot);
   server.on(F("/health"), HTTP_GET, handleHealthCheck);
-  server.on(F("/counter"), HTTP_DELETE, handleResetCounter);
+  server.on(F("/pzems/counter"), HTTP_DELETE, handleResetCounter);
+  server.on(F("/pzems/address"), HTTP_PATCH, handlePzemAddressChange);
   server.on(F("/time"), HTTP_GET, handleTime);
   server.on(F("/time/sync"), HTTP_POST, handleTimeUpdate);
   server.onNotFound(handleNotFound);
@@ -48,13 +49,34 @@ void handleHealthCheck() {
   digitalWrite(LED_BUILTIN, HIGH);
 }
 
-// DELETE "/counter"
+// DELETE "/pzems/counter"
 void handleResetCounter() {
   digitalWrite(LED_BUILTIN, LOW);
 
   resetEnergyCounter();
 
   server.send(HTTP_CODE_NO_CONTENT);
+
+  digitalWrite(LED_BUILTIN, HIGH);
+}
+
+// PATCH "/pzems/address"
+void handlePzemAddressChange() {
+  digitalWrite(LED_BUILTIN, LOW);
+
+  long address = 0;
+
+  for (uint8_t i = 0; i < server.args(); i++) {
+    if (server.argName(i) == F("address")) {
+      address = server.arg(i).toInt();
+    }
+  }
+
+  if (address >= 1 && address <= 247) {
+    server.send(HTTP_CODE_OK, F("application/json"), changePzemAddress(address));
+  } else {
+    server.send(HTTP_CODE_BAD_REQUEST, F("text/plain"), F("The \"address\" query param should be in the range between 1 and 247"));
+  }
 
   digitalWrite(LED_BUILTIN, HIGH);
 }

--- a/src/lightControl/04-server.ino
+++ b/src/lightControl/04-server.ino
@@ -22,22 +22,16 @@ void handleClient() {
 }
 
 void configRouter() {
-  server.on(F("/"), HTTP_GET, handleRoot);
   server.on(F("/health"), HTTP_GET, handleHealthCheck);
-  server.on(F("/pzems/counter"), HTTP_DELETE, handleResetCounter);
+
+  server.on(F("/pzems"), HTTP_GET, handlePzemValues);
   server.on(F("/pzems/address"), HTTP_PATCH, handlePzemAddressChange);
+  server.on(F("/pzems/counter"), HTTP_DELETE, handleCounterReset);
+
   server.on(F("/time"), HTTP_GET, handleTime);
   server.on(F("/time/sync"), HTTP_POST, handleTimeUpdate);
+
   server.onNotFound(handleNotFound);
-}
-
-// GET "/"
-void handleRoot() {
-  digitalWrite(LED_BUILTIN, LOW);
-
-  server.send(HTTP_CODE_OK, F("application/json"), collectPzemPayload());
-
-  digitalWrite(LED_BUILTIN, HIGH);
 }
 
 // GET "/health"
@@ -49,13 +43,11 @@ void handleHealthCheck() {
   digitalWrite(LED_BUILTIN, HIGH);
 }
 
-// DELETE "/pzems/counter"
-void handleResetCounter() {
+// GET "/pzems"
+void handlePzemValues() {
   digitalWrite(LED_BUILTIN, LOW);
 
-  resetEnergyCounter();
-
-  server.send(HTTP_CODE_NO_CONTENT);
+  server.send(HTTP_CODE_OK, F("application/json"), collectPzemPayload());
 
   digitalWrite(LED_BUILTIN, HIGH);
 }
@@ -77,6 +69,17 @@ void handlePzemAddressChange() {
   } else {
     server.send(HTTP_CODE_BAD_REQUEST, F("text/plain"), F("The \"address\" query param should be in the range between 1 and 247"));
   }
+
+  digitalWrite(LED_BUILTIN, HIGH);
+}
+
+// DELETE "/pzems/counter"
+void handleCounterReset() {
+  digitalWrite(LED_BUILTIN, LOW);
+
+  resetEnergyCounter();
+
+  server.send(HTTP_CODE_NO_CONTENT);
 
   digitalWrite(LED_BUILTIN, HIGH);
 }

--- a/src/lightControl/04-server.ino
+++ b/src/lightControl/04-server.ino
@@ -22,11 +22,11 @@ void handleClient() {
 }
 
 void configRouter() {
-  server.on("/", HTTP_GET, handleRoot);
-  server.on("/health", HTTP_GET, handleHealthCheck);
-  server.on("/counter", HTTP_DELETE, handleResetCounter);
-  server.on("/time", HTTP_GET, handleTime);
-  server.on("/time/sync", HTTP_POST, handleTimeUpdate);
+  server.on(F("/"), HTTP_GET, handleRoot);
+  server.on(F("/health"), HTTP_GET, handleHealthCheck);
+  server.on(F("/counter"), HTTP_DELETE, handleResetCounter);
+  server.on(F("/time"), HTTP_GET, handleTime);
+  server.on(F("/time/sync"), HTTP_POST, handleTimeUpdate);
   server.onNotFound(handleNotFound);
 }
 
@@ -34,7 +34,7 @@ void configRouter() {
 void handleRoot() {
   digitalWrite(LED_BUILTIN, LOW);
 
-  server.send(HTTP_CODE_OK, "application/json", pzemToJson(getPzemValues()));
+  server.send(HTTP_CODE_OK, F("application/json"), collectPzemPayload());
 
   digitalWrite(LED_BUILTIN, HIGH);
 }
@@ -43,7 +43,7 @@ void handleRoot() {
 void handleHealthCheck() {
   digitalWrite(LED_BUILTIN, LOW);
 
-  server.send(HTTP_CODE_OK, "text/plain", "UP");
+  server.send(HTTP_CODE_OK, F("text/plain"), F("UP"));
 
   digitalWrite(LED_BUILTIN, HIGH);
 }
@@ -63,7 +63,7 @@ void handleResetCounter() {
 void handleTime() {
   digitalWrite(LED_BUILTIN, LOW);
 
-  server.send(HTTP_CODE_OK, "application/json", getNTPStatus());
+  server.send(HTTP_CODE_OK, F("application/json"), getNTPStatus());
 
   digitalWrite(LED_BUILTIN, HIGH);
 }
@@ -74,7 +74,7 @@ void handleTimeUpdate() {
 
   uint8_t status = updateTime();
 
-  server.send(HTTP_CODE_OK, "application/json", getNTPStatusWithUpdateStatus(status));
+  server.send(HTTP_CODE_OK, F("application/json"), getNTPStatusWithUpdateStatus(status));
 
   digitalWrite(LED_BUILTIN, HIGH);
 }
@@ -83,7 +83,7 @@ void handleTimeUpdate() {
 void handleNotFound() {
   digitalWrite(LED_BUILTIN, LOW);
 
-  server.send(HTTP_CODE_NOT_FOUND, "text/plain", "Route Not Found");
+  server.send(HTTP_CODE_NOT_FOUND, F("text/plain"), F("Route Not Found"));
 
   digitalWrite(LED_BUILTIN, HIGH);
 }

--- a/src/lightControl/05-time.ino
+++ b/src/lightControl/05-time.ino
@@ -28,12 +28,12 @@ String getNTPStatus() {
   JsonDocument doc;
   String result;
 
-  doc["status"] = ntp.status();
-  doc["isSynced"] = ntp.synced();
-  doc["isBusy"] = ntp.busy();
-  doc["ping"] = ntp.ping();
-  doc["isoDate"] = toISODateString(getDate());
-  doc["tickStatus"] = ntp.tick();
+  doc[F("status")] = ntp.status();
+  doc[F("isSynced")] = ntp.synced();
+  doc[F("isBusy")] = ntp.busy();
+  doc[F("ping")] = ntp.ping();
+  doc[F("isoDate")] = toISODateString(getDate());
+  doc[F("tickStatus")] = ntp.tick();
 
   serializeJson(doc, result);
 
@@ -44,13 +44,13 @@ String getNTPStatusWithUpdateStatus(uint8_t updateStatus) {
   JsonDocument doc;
   String result;
 
-  doc["status"] = ntp.status();
-  doc["isSynced"] = ntp.synced();
-  doc["isBusy"] = ntp.busy();
-  doc["ping"] = ntp.ping();
-  doc["isoDate"] = toISODateString(getDate());
-  doc["tickStatus"] = ntp.tick();
-  doc["updateStatus"] = updateStatus;
+  doc[F("status")] = ntp.status();
+  doc[F("isSynced")] = ntp.synced();
+  doc[F("isBusy")] = ntp.busy();
+  doc[F("ping")] = ntp.ping();
+  doc[F("isoDate")] = toISODateString(getDate());
+  doc[F("tickStatus")] = ntp.tick();
+  doc[F("updateStatus")] = updateStatus;
 
   serializeJson(doc, result);
 
@@ -69,49 +69,49 @@ Date getDate() {
   };
 }
 
-String toISODateString(Date date) {
+String toISODateString(const Date &date) {
   String str;
   str.reserve(24);
 
   str += date.year;
-  str += "-";
+  str += F("-");
 
   if (date.month < 10) {
-    str += "0";
+    str += F("0");
   }
   str += date.month;
-  str += "-";
+  str += F("-");
 
   if (date.day < 10) {
-    str += "0";
+    str += F("0");
   }
   str += date.day;
 
-  str += "T";
+  str += F("T");
 
   if (date.hour < 10) {
-    str += "0";
+    str += F("0");
   }
   str += date.hour;
-  str += ":";
+  str += F(":");
 
   if (date.minute < 10) {
-    str += "0";
+    str += F("0");
   }
   str += date.minute;
-  str += ":";
+  str += F(":");
 
   if (date.second < 10) {
-    str += "0";
+    str += F("0");
   }
   str += date.second;
-  str += ".";
+  str += F(".");
 
   if (date.ms < 100) {
-    str += "0";
+    str += F("0");
   }
   str += date.ms;
-  str += "Z";
+  str += F("Z");
 
   return str;
 }

--- a/src/lightControl/06-client.ino
+++ b/src/lightControl/06-client.ino
@@ -6,7 +6,7 @@ void streamPzemValues() {
   if (currentMillis - previousMillis >= POST_PZEM_INTERVAL) {
     previousMillis = currentMillis;
 
-    jsonPOST(POST_PZEM_ENDPOINT, pzemToJson(getPzemValues()));
+    jsonPOST(POST_PZEM_ENDPOINT, collectPzemPayload());
   }
 }
 
@@ -18,7 +18,7 @@ void jsonPOST(String endpoint, String payload) {
   Serial.println(endpoint);
 
   http.begin(client, endpoint);
-  http.addHeader("Content-Type", "application/json");
+  http.addHeader(F("Content-Type"), F("application/json"));
 
   // NB: HttpClient works synchronously
   int httpCode = http.POST(payload);

--- a/src/lightControl/lightControl.ino
+++ b/src/lightControl/lightControl.ino
@@ -57,5 +57,5 @@ void loop() {
   syncTime();
 
   handleClient();
-  // streamPzemValues();
+  streamPzemValues();
 }

--- a/src/lightControl/lightControl.ino
+++ b/src/lightControl/lightControl.ino
@@ -27,6 +27,13 @@ struct Pzem {
   Date createdAt;
 };
 
+struct Zone {
+  float t1StartEnergy;
+  float t2StartEnergy;
+  float t1EnergyAcc;
+  float t2EnergyAcc;
+};
+
 void initLedPins() {
   pinMode(LED_BUILTIN, OUTPUT);
 }
@@ -50,5 +57,5 @@ void loop() {
   syncTime();
 
   handleClient();
-  streamPzemValues();
+  // streamPzemValues();
 }


### PR DESCRIPTION
## Description

- Add multiple AC PZEM sensors support on the same Modbus, using slave PZEM addresses. According to [datasheet](https://arduino.ua/files/PZEM-004T-V3_0-Datasheet-User-Manual.pdf), the address range of the slave is 0x01 ~ 0xF7;
- Add PATCH endpoint to change the address of connected PZEM;
- Reduce 540 bytes of SRAM using flash-strings

## After

<img width="558" alt="Screenshot 2024-06-08 at 9 53 57 PM" src="https://github.com/AndriiKitsun/solar-control-arduino/assets/44744145/fb414b43-dfcf-4d4c-b46c-55cfa64694f8">
