### PR TITLE
SC-33: Send single createdAt field shared between PZEMs

### DIFF
--- a/include/pzems/acpzem.h
+++ b/include/pzems/acpzem.h
@@ -18,7 +18,7 @@ class AcPzem {
  public:
   AcPzem(SoftwareSerial& port, uint8_t addr = PZEM_DEFAULT_ADDR);
 
-  JsonDocument getValues();
+  JsonDocument getValues(const Date& date);
   JsonDocument changeAddress(uint8_t addr);
   void resetCounter();
 

--- a/include/utils/date.h
+++ b/include/utils/date.h
@@ -21,7 +21,6 @@ void tickNTP();
 
 Date getDate();
 
-String getISODateString();
 String toISODateString(const Date& date);
 
 #endif

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -103,11 +103,20 @@ String getPzemsPayload() {
   JsonDocument doc;
   String payload;
 
-  doc[F("acInputPzem")].to<JsonObject>();
-  doc[F("acOutputPzem")].to<JsonObject>();
+  Date date = getDate();
 
-  doc[F("acInputPzem")] = acInputPzem.getValues();
-  doc[F("acOutputPzem")] = acOutputPzem.getValues();
+  doc[F("createdAtGmt")] = toISODateString(date);
+
+  JsonDocument acInputValues = acInputPzem.getValues(date);
+  JsonDocument acOutputValues = acOutputPzem.getValues(date);
+
+  if (!acInputValues.isNull()) {
+    doc[F("acInputPzem")] = acInputValues;
+  }
+
+  if (!acOutputValues.isNull()) {
+    doc[F("acOutputPzem")] = acOutputValues;
+  }
 
   serializeJson(doc, payload);
 

--- a/src/pzems/acpzem.cpp
+++ b/src/pzems/acpzem.cpp
@@ -6,8 +6,10 @@ AcPzem::AcPzem(SoftwareSerial& port, uint8_t addr)
     : _pzem(port, addr), _zone{0.0, 0.0, 0.0, 0.0} {
 }
 
-JsonDocument AcPzem::getValues() {
+JsonDocument AcPzem::getValues(const Date& date) {
   JsonDocument doc;
+
+  _createdAt = date;
 
   readValues();
 
@@ -39,8 +41,6 @@ JsonDocument AcPzem::getValues() {
     doc[F("t2EnergyKwh")] = _t2Energy;
   }
 
-  doc[F("createdAtGmt")] = toISODateString(_createdAt);
-
   return doc;
 }
 
@@ -68,7 +68,6 @@ void AcPzem::resetCounter() {
 
 void AcPzem::readValues() {
   _voltage = _pzem.voltage();
-  _createdAt = getDate();
 
   // If the value can't be read - skip further sensor polling
   if (isnan(_voltage)) {

--- a/src/utils/date.cpp
+++ b/src/utils/date.cpp
@@ -36,10 +36,6 @@ Date getDate() {
   };
 }
 
-String getISODateString() {
-  return toISODateString(getDate());
-}
-
 String toISODateString(const Date& date) {
   String str;
   str.reserve(24);


### PR DESCRIPTION
## Description

- Extract the `createdAt` field from the PZEM class and make it common across all PZEM instances to ensure data is calculated at the same time.

## After

<img width="543" alt="image" src="https://github.com/user-attachments/assets/7272b4c9-f1d9-4e29-b7f4-ec29252ac45e">
