### PR TITLE
SC-36: PZEM values are not cleared when PZEM is disconnected

### DIFF
--- a/src/pzems/acpzem.cpp
+++ b/src/pzems/acpzem.cpp
@@ -21,6 +21,10 @@ JsonDocument AcPzem::getValues(const Date& date) {
     doc[F("currentA")] = _current;
   }
 
+  if (_power) {
+    doc[F("powerKw")] = _power;
+  }
+
   if (_energy) {
     doc[F("energyKwh")] = _energy;
   }
@@ -69,9 +73,17 @@ void AcPzem::resetCounter() {
 void AcPzem::readValues() {
   _voltage = _pzem.voltage();
 
-  // If the value can't be read - skip further sensor polling
+  // If sensor is disconnected - clear values and skip further sensor polling
   if (isnan(_voltage)) {
-    _voltage = 0;
+    _voltage = 0.0;
+    _current = 0.0;
+    _power = 0.0;
+    _energy = 0.0;
+    _frequency = 0.0;
+    _powerFactor = 0.0;
+    _t1Energy = 0.0;
+    _t2Energy = 0.0;
+
     return;
   }
 

--- a/src/websocket/websocket.cpp
+++ b/src/websocket/websocket.cpp
@@ -5,7 +5,7 @@ WebSocketsServer webSocket(81);
 void startWebSocket() {
   webSocket.begin();
 
-  Serial.println(F("Websocket started on:"));
+  Serial.println(F("WebSocket started on:"));
   Serial.print(F("1. IP address: ws://"));
   Serial.print(WiFi.localIP());
   Serial.println(F(":81"));


### PR DESCRIPTION
## Description

- Clear the PZEM sensor values in the event of an accidental disconnection.

## Before

![Screenshot 2024-08-13 at 2 49 32 PM](https://github.com/user-attachments/assets/8e3a99f1-96ef-4e89-9bca-7ea27095e0dd)

## After

![Screenshot 2024-08-13 at 2 49 59 PM](https://github.com/user-attachments/assets/64c9b037-c24a-4545-91ee-f5dc2d5d9fb0)
