### PR TITLE
SC-27: PZEM-017 DC sensor integration

### DIFF
--- a/include/http/server.h
+++ b/include/http/server.h
@@ -7,6 +7,7 @@
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>
 #include "pzems/acpzem.h"
+#include "pzems/dcpzem.h"
 #include "utils/led.h"
 
 void startServer();
@@ -16,10 +17,13 @@ void configRouter();
 
 void handleHealthCheck();
 void handlePzemValues();
+void handlePzemsStatus();
 void handlePzemAddressChange();
+void handlePzemShuntChange();
 void handlePzemsCounterReset();
 void handleNotFound();
 
 String getPzemsPayload();
+String getPzemsStatus();
 
 #endif

--- a/include/pzems/acpzem.h
+++ b/include/pzems/acpzem.h
@@ -20,9 +20,6 @@ class AcPzem : public Pzem {
  private:
   PZEM004Tv30 _pzem;
 
-  float _voltage;
-  float _current;
-  float _power;
   float _frequency;
   float _powerFactor;
 

--- a/include/pzems/acpzem.h
+++ b/include/pzems/acpzem.h
@@ -18,7 +18,9 @@ class AcPzem {
  public:
   AcPzem(SoftwareSerial& port, uint8_t addr = PZEM_DEFAULT_ADDR);
 
+  JsonDocument getStatus();
   JsonDocument getValues(const Date& date);
+
   JsonDocument changeAddress(uint8_t addr);
   void resetCounter();
 

--- a/include/pzems/acpzem.h
+++ b/include/pzems/acpzem.h
@@ -5,16 +5,9 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <PZEM004Tv30.h>
-#include "utils/date.h"
+#include "pzem.h"
 
-struct Zone {
-  float t1StartEnergy;
-  float t2StartEnergy;
-  float t1EnergyAcc;
-  float t2EnergyAcc;
-};
-
-class AcPzem {
+class AcPzem : public Pzem {
  public:
   AcPzem(SoftwareSerial& port, uint8_t addr = PZEM_DEFAULT_ADDR);
 
@@ -26,32 +19,14 @@ class AcPzem {
 
  private:
   PZEM004Tv30 _pzem;
-  Zone _zone;
 
   float _voltage;
   float _current;
   float _power;
-  float _energy;
   float _frequency;
   float _powerFactor;
-  float _t1Energy;
-  float _t2Energy;
-  Date _createdAt;
 
   void readValues();
-
-  void calcZoneEnergy();
-
-  float calcT1ZoneEnergy();
-  float calcT2ZoneEnergy();
-
-  bool isT1ZoneActive(uint8_t hour);
-
-  bool isStartOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second);
-  bool isEndOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second);
-
-  bool isStartOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second);
-  bool isEndOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second);
 };
 
 #endif

--- a/include/pzems/dcpzem.h
+++ b/include/pzems/dcpzem.h
@@ -5,13 +5,14 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <PZEM017v1.h>
+#include "pzem.h"
 
-class DcPzem {
+class DcPzem : public Pzem {
  public:
   DcPzem(SoftwareSerial& port, uint8_t addr = PZEM017_DEFAULT_ADDR);
 
   JsonDocument getStatus();
-  JsonDocument getValues();
+  JsonDocument getValues(const Date& date);
 
   JsonDocument changeAddress(uint8_t addr);
   JsonDocument changeShuntType(uint16_t type);
@@ -23,7 +24,6 @@ class DcPzem {
   float _voltage;
   float _current;
   float _power;
-  float _energy;
 
   void readValues();
 };

--- a/include/pzems/dcpzem.h
+++ b/include/pzems/dcpzem.h
@@ -21,10 +21,6 @@ class DcPzem : public Pzem {
  private:
   PZEM017v1 _pzem;
 
-  float _voltage;
-  float _current;
-  float _power;
-
   void readValues();
 };
 

--- a/include/pzems/dcpzem.h
+++ b/include/pzems/dcpzem.h
@@ -1,0 +1,31 @@
+#pragma once
+#ifndef DCPZEM_H
+#define DCPZEM_H
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <PZEM017v1.h>
+
+class DcPzem {
+ public:
+  DcPzem(SoftwareSerial& port, uint8_t addr = PZEM017_DEFAULT_ADDR);
+
+  JsonDocument getStatus();
+  JsonDocument getValues();
+
+  JsonDocument changeAddress(uint8_t addr);
+  JsonDocument changeShuntType(uint16_t type);
+  void resetCounter();
+
+ private:
+  PZEM017v1 _pzem;
+
+  float _voltage;
+  float _current;
+  float _power;
+  float _energy;
+
+  void readValues();
+};
+
+#endif

--- a/include/pzems/pzem.h
+++ b/include/pzems/pzem.h
@@ -16,7 +16,12 @@ class Pzem {
  protected:
   Zone _zone;
   Date _createdAt;
+
+  float _voltage;
+  float _current;
+  float _power;
   float _energy;
+
   float _t1Energy;
   float _t2Energy;
 

--- a/include/pzems/pzem.h
+++ b/include/pzems/pzem.h
@@ -1,0 +1,37 @@
+#pragma once
+#ifndef PZEM_H
+#define PZEM_H
+
+#include <Arduino.h>
+#include "utils/date.h"
+
+struct Zone {
+  float t1StartEnergy;
+  float t2StartEnergy;
+  float t1EnergyAcc;
+  float t2EnergyAcc;
+};
+
+class Pzem {
+ protected:
+  Zone _zone;
+  Date _createdAt;
+  float _energy;
+  float _t1Energy;
+  float _t2Energy;
+
+  void calcZoneEnergy();
+
+  float calcT1ZoneEnergy();
+  float calcT2ZoneEnergy();
+
+  bool isT1ZoneActive(uint8_t hour);
+
+  bool isStartOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second);
+  bool isEndOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second);
+
+  bool isStartOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second);
+  bool isEndOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second);
+};
+
+#endif

--- a/lib/PZEM-017-v1/PZEM017v1.cpp
+++ b/lib/PZEM-017-v1/PZEM017v1.cpp
@@ -1,0 +1,726 @@
+/*
+
+Copyright (c) 2020 Maxz Maxzerker (for PZEM-017)
+Copyright (c) 2019 Jakub Mandula
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "PZEM017v1.h"
+#include <stdio.h>
+
+#define REG_VOLTAGE 0x0000
+#define REG_CURRENT 0x0001
+#define REG_POWER_L 0x0002
+#define REG_POWER_H 0x0003
+#define REG_ENERGY_L 0x0004
+#define REG_ENERGY_H 0x0005
+#define REG_HVALARM 0x0006
+#define REG_LVALARM 0x0007
+
+#define CMD_RHR 0x03
+#define CMD_RIR 0X04
+#define CMD_WSR 0x06
+#define CMD_CAL 0x41
+#define CMD_REST 0x42
+
+#define SHUNT_100A 0x0000
+#define SHUNT_50A 0x0001
+#define SHUNT_200A 0x0002
+#define SHUNT_300A 0x0003
+
+#define WREG_HV_ALARM_THR 0x0000
+#define WREG_LV_ALARM_THR 0x0001
+#define WREG_ADDR 0x0002
+#define WREG_SHUNT 0x0003
+
+#define UPDATE_TIME 200
+
+#define RESPONSE_SIZE 32
+#define READ_TIMEOUT 100
+
+#define PZEM_BAUD_RATE 9600
+
+extern HardwareSerial Serial;
+
+#define DEBUG
+
+// Debugging function;
+void printBuf(uint8_t* buffer, uint16_t len) {
+#ifdef DEBUG
+  for (uint16_t i = 0; i < len; i++) {
+    char temp[6];
+    sprintf(temp, "%.2x ", buffer[i]);
+    Serial.print(temp);
+  }
+  Serial.println();
+#endif
+}
+
+/*!
+ * PZEM017v1::PZEM017v1
+ *
+ * Software Serial constructor
+ *
+ * @param receivePin RX pin
+ * @param transmitPin TX pin
+ * @param addr Slave address of device
+ */
+#if defined(PZEM004_SOFTSERIAL)
+PZEM017v1::PZEM017v1(SoftwareSerial& port, uint8_t addr) {
+  port.begin(PZEM_BAUD_RATE);
+
+  this->_serial = (Stream*)&port;
+  this->_isSoft = true;
+
+  init(addr);
+}
+#endif
+
+/*!
+ * PZEM017v1::PZEM017v1
+ *
+ * Hardware serial constructor
+ *
+ * @param port Hardware serial to use
+ * @param addr Slave address of device
+ */
+PZEM017v1::PZEM017v1(HardwareSerial* port, uint8_t addr) {
+  port->begin(PZEM_BAUD_RATE);
+  this->_serial = port;
+  this->_isSoft = false;
+  init(addr);
+}
+
+/*!
+ * PZEM017v1::~PZEM017v1
+ *
+ * Destructor deleting software serial
+ *
+ */
+PZEM017v1::~PZEM017v1() {
+  if (_isSoft)
+    delete this->_serial;
+}
+
+/*!
+ * PZEM017v1::voltage
+ *
+ * Get line voltage in Volts
+ *
+ * @return current L-N volage
+ */
+float PZEM017v1::voltage() {
+  if (!updateValues())  // Update vales if necessary
+    return NAN;         // Update did not work, return NAN
+
+  return _currentValues.voltage;
+}
+
+/*!
+ * PZEM017v1::current
+ *
+ * Get line in Amps
+ *
+ * @return line current
+ */
+float PZEM017v1::current() {
+  if (!updateValues())  // Update vales if necessary
+    return NAN;         // Update did not work, return NAN
+
+  return _currentValues.current;
+}
+
+/*!
+ * PZEM017v1::power
+ *
+ * Get Active power in W
+ *
+ * @return active power in W
+ */
+float PZEM017v1::power() {
+  if (!updateValues())  // Update vales if necessary
+    return NAN;         // Update did not work, return NAN
+
+  return _currentValues.power;
+}
+
+/*!
+ * PZEM017v1::energy
+ *
+ * Get Active energy in kWh since last reset
+ *
+ * @return active energy in kWh
+ */
+float PZEM017v1::energy() {
+  if (!updateValues())  // Update vales if necessary
+    return NAN;         // Update did not work, return NAN
+
+  return _currentValues.energy;
+}
+
+/*!
+ * PZEM017v1::sendCmd8
+ *
+ * Prepares the 8 byte command buffer and sends
+ *
+ * @param[in] cmd - Command to send (position 1)
+ * @param[in] rAddr - Register address (postion 2-3)
+ * @param[in] val - Register value to write (positon 4-5)
+ * @param[in] check - perform a simple read check after write
+ *
+ * @return success
+ */
+bool PZEM017v1::sendCmd8(uint8_t cmd, uint16_t rAddr, uint16_t val, bool check, uint16_t slave_addr) {
+  uint8_t sendBuffer[8];  // Send buffer
+  uint8_t respBuffer[8];  // Response buffer (only used when check is true)
+
+  if ((slave_addr == 0xFFFF) ||
+      (slave_addr < 0x01) ||
+      (slave_addr > 0xF7)) {
+    slave_addr = _addr;
+  }
+
+  sendBuffer[0] = slave_addr;  // Set slave address
+  sendBuffer[1] = cmd;         // Set command
+
+  sendBuffer[2] = (rAddr >> 8) & 0xFF;  // Set high byte of register address
+  sendBuffer[3] = (rAddr) & 0xFF;       // Set low byte =//=
+
+  sendBuffer[4] = (val >> 8) & 0xFF;  // Set high byte of register value
+  sendBuffer[5] = (val) & 0xFF;       // Set low byte =//=
+
+  setCRC(sendBuffer, 8);  // Set CRC of frame
+
+  _serial->write(sendBuffer, 8);  // send frame
+
+  if (check) {
+    if (!recieve(respBuffer, 8)) {  // if check enabled, read the response
+      return false;
+    }
+
+    // Check if response is same as send
+    for (uint8_t i = 0; i < 8; i++) {
+      if (sendBuffer[i] != respBuffer[i])
+        return false;
+    }
+  }
+  return true;
+}
+
+/*!
+ * PZEM017v1::setAddress
+ *
+ * Set a new device address and update the device
+ * WARNING - should be used to set up devices once.
+ * Code initializtion will still have old address on next run!
+ *
+ * @param[in] addr New device address 0x01-0xF7
+ *
+ * @return success
+ */
+bool PZEM017v1::setAddress(uint8_t addr) {
+  if (addr < 0x01 || addr > 0xF7)  // sanity check
+    return false;
+
+  // Write the new address to the address register
+  if (!sendCmd8(CMD_WSR, WREG_ADDR, addr, true))
+    return false;
+
+  _addr = addr;  // If successful, update the current slave address
+
+  return true;
+}
+
+/*!
+ * PZEM017v1::getAddress
+ *
+ * Get the current device address
+ *
+ * @return address
+ */
+uint8_t PZEM017v1::getAddress() {
+  return _addr;
+}
+
+/*!
+ * PZEM017v1::isHighVoltAlarmOn
+ *
+ * Is the HV alarm set
+ *
+ *
+ * @return alarm triggerd
+ */
+bool PZEM017v1::isHighvoltAlarmOn() {
+  if (!updateValues())  // Update vales if necessary
+    return NAN;         // Update did not work, return NAN
+
+  return _currentValues.HVAlarms != 0x0000;
+}
+
+/*!
+ * PZEM017v1::isLowVoltAlarmOn
+ *
+ * Is the LV alarm set
+ *
+ *
+ * @return alarm triggerd
+ */
+bool PZEM017v1::isLowvoltAlarmOn() {
+  if (!updateValues())  // Update vales if necessary
+    return NAN;         // Update did not work, return NAN
+
+  return _currentValues.LVAlarms != 0x0000;
+}
+
+/*!
+ * PZEM017v1::init
+ *
+ * initialization common to all consturctors
+ *
+ * @param[in] addr - device address
+ *
+ * @return success
+ */
+void PZEM017v1::init(uint8_t addr) {
+  if (addr < 0x01 || addr > 0xF8)  // Sanity check of address
+    addr = PZEM017_DEFAULT_ADDR;
+  _addr = addr;
+
+  // Set initial lastRed time so that we read right away
+  _lastInputRead = 0;
+  _lastInputRead -= UPDATE_TIME;
+
+  _lastHoldingRead = 0;
+  _lastHoldingRead -= UPDATE_TIME;
+}
+
+/*!
+ * PZEM017v1::getParameters()
+ *
+ * Read all parameters of device and update the local values
+ *
+ * @return success
+ */
+bool PZEM017v1::getParameters() {
+  static uint8_t response[13];
+
+  // If we read before the update time limit, do not update
+  if (_lastHoldingRead + UPDATE_TIME > millis()) {
+    return true;
+  }
+
+  // Read 3 registers starting at 0x00
+  sendCmd8(CMD_RHR, 0x00, 0x04, false);
+
+  if (recieve(response, 13) != 13) {  // Something went wrong
+    return false;
+  }
+
+  // Update the current paramaters
+  _parameterValues.HVAlarmVoltage = ((uint32_t)response[3] << 8 |  // Raw voltage in 0.01V
+                                     (uint32_t)response[4]) /
+                                    100.0;
+
+  _parameterValues.LVAlarmVoltage = ((uint32_t)response[5] << 8 |  // Raw voltage in 0.01V
+                                     (uint32_t)response[6]) /
+                                    100.0;
+
+  _parameterValues.address = ((uint32_t)response[7] << 8 |  // Raw address 0x00-0xf7
+                              (uint32_t)response[8]);
+
+  _parameterValues.shunttype = ((uint32_t)response[9] << 8 |  // Shunt type 0x0000 - 0x0003 (100A/50A/200A/300A)
+                                (uint32_t)response[10]);
+  // Record current time as _lastHoldingRead
+  _lastHoldingRead = millis();
+
+  return true;
+}
+
+/*!
+ * PZEM017v1::GetHighVoltAlarmValue
+ *
+ * Current HV alarm value
+ *
+ *
+ * @return alarm value
+ */
+float PZEM017v1::getHighvoltAlarmValue() {
+  if (!getParameters())
+    return NAN;
+
+  return _parameterValues.HVAlarmVoltage;
+}
+
+/*!
+ * PZEM017v1::GetLowvoltAlarmValue
+ *
+ * Current LV alarm value
+ *
+ *
+ * @return alarm value
+ */
+float PZEM017v1::getLowvoltAlarmValue() {
+  if (!getParameters())
+    return NAN;
+
+  return _parameterValues.LVAlarmVoltage;
+}
+
+/*!
+ * PZEM017v1::address
+ *
+ * Current address
+ *
+ *
+ * @return device address
+ */
+uint16_t PZEM017v1::getHoldingAddress() {
+  if (!getParameters())
+    return NAN;
+
+  return _parameterValues.address;
+}
+
+/*!
+ * PZEM017v1::shunttype
+ *
+ * Current shuttype
+ *
+ *
+ * @return device shuttype
+ */
+uint16_t PZEM017v1::getShunttype() {
+  if (!getParameters())
+    return NAN;
+
+  return _parameterValues.shunttype;
+}
+
+/*!
+ * PZEM017v1::updateValues
+ *
+ * Read all registers of device and update the local values
+ *
+ * @return success
+ */
+bool PZEM017v1::updateValues() {
+  // static uint8_t buffer[] = {0x00, CMD_RIR, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00};
+  static uint8_t response[21];
+
+  // If we read before the update time limit, do not update
+  if (_lastInputRead + UPDATE_TIME > millis()) {
+    return true;
+  }
+
+  // Read 10 registers starting at 0x00 (no check)
+  sendCmd8(CMD_RIR, 0x00, 0x08, false);
+
+  if (recieve(response, 21) != 21) {  // Something went wrong
+    return false;
+  }
+  // Update the current values
+  _currentValues.voltage = ((uint32_t)response[3] << 8 |  // Raw voltage in 0.01V
+                            (uint32_t)response[4]) /
+                           100.0;
+
+  _currentValues.current = ((uint32_t)response[5] << 8 |  // Raw voltage in 0.01A
+                            (uint32_t)response[6]) /
+                           100.0;
+
+  _currentValues.power = ((uint32_t)response[7] << 8 |  // Raw power in 0.1W
+                          (uint32_t)response[8] |
+                          (uint32_t)response[9] << 24 |
+                          (uint32_t)response[10] << 16) /
+                         10.0;
+
+  _currentValues.energy = ((uint32_t)response[11] << 8 |  // Raw Energy in 1Wh
+                           (uint32_t)response[12] |
+                           (uint32_t)response[13] << 24 |
+                           (uint32_t)response[14] << 16) /
+                          1000.0;
+
+  _currentValues.HVAlarms = ((uint32_t)response[15] << 8 |  // Raw alarm value
+                             (uint32_t)response[16]);
+
+  _currentValues.LVAlarms = ((uint32_t)response[17] << 8 |  // Raw alarm value
+                             (uint32_t)response[18]);
+  // Record current time as _lastInputRead
+  _lastInputRead = millis();
+
+  // for(int i = 0; i < sizeof(response); i++){
+  //     Serial.println(response[i]);
+  // }
+
+  return true;
+}
+
+/*!
+ * PZEM017v1::resetEnergy
+ *
+ * Reset the Energy counter on the device
+ *
+ * @return success
+ */
+bool PZEM017v1::resetEnergy() {
+  uint8_t buffer[] = {0x00, CMD_REST, 0x00, 0x00};
+  uint8_t reply[5];
+  buffer[0] = _addr;
+
+  setCRC(buffer, 4);
+  _serial->write(buffer, 4);
+
+  uint16_t length = recieve(reply, 5);
+
+  if (length == 0 || length == 5) {
+    return false;
+  }
+
+  return true;
+}
+
+/*!
+ * PZEM017v1::setHighVoltAlarm
+ *
+ * Set HV alarm threshold in volts
+ *
+ * @param[in] volt Alarm theshold
+ *
+ * @return success
+ */
+bool PZEM017v1::setShuntType(uint16_t type) {
+  if (type < 0) {  // Sanity check
+    type = 0;
+  }
+
+  if (type > 3) {
+    type = 3;
+  }
+
+  // Write shunt type to the holding register
+  if (!sendCmd8(CMD_WSR, WREG_SHUNT, type, true))
+    return false;
+
+  return true;
+}
+
+/*!
+ * PZEM017v1::setHighVoltAlarm
+ *
+ * Set HV alarm threshold in volts
+ *
+ * @param[in] volt Alarm theshold
+ *
+ * @return success
+ */
+bool PZEM017v1::setHighvoltAlarm(uint16_t volts) {
+  if (volts < 500) {  // Sanity check
+    volts = 500;
+  }
+
+  if (volts > 34999) {  // Sanity check
+    volts = 34999;
+  }
+
+  // Write the volts threshold to the alarm register
+  if (!sendCmd8(CMD_WSR, WREG_HV_ALARM_THR, volts, true))
+    return false;
+
+  return true;
+}
+
+/*!
+ * PZEM017v1::setLowVoltAlarm
+ *
+ * Set LV alarm threshold in volts
+ *
+ * @param[in] volt Alarm theshold
+ *
+ * @return success
+ */
+bool PZEM017v1::setLowvoltAlarm(uint16_t volts) {
+  if (volts < 100) {  // Sanity check
+    volts = 100;
+  }
+
+  if (volts > 34999) {  // Sanity check
+    volts = 34999;
+  }
+
+  // Write the volts threshold to the alarm register
+  if (!sendCmd8(CMD_WSR, WREG_LV_ALARM_THR, volts, true))
+    return false;
+
+  return true;
+}
+
+/*!
+ * PZEM017v1::recieve
+ *
+ * Receive data from serial with buffer limit and timeout
+ *
+ * @param[out] resp Memory buffer to hold response. Must be at least `len` long
+ * @param[in] len Max number of bytes to read
+ *
+ * @return number of bytes read
+ */
+uint16_t PZEM017v1::recieve(uint8_t* resp, uint16_t len) {
+#ifdef PZEM004_SOFTSERIAL
+  if (_isSoft)
+    ((SoftwareSerial*)_serial)->listen();  // Start software serial listen
+#endif
+
+  unsigned long startTime = millis();  // Start time for Timeout
+  uint8_t index = 0;                   // Bytes we have read
+  while ((index < len) && (millis() - startTime < READ_TIMEOUT)) {
+    if (_serial->available() > 0) {
+      uint8_t c = (uint8_t)_serial->read();
+
+      resp[index++] = c;
+    }
+    yield();  // do background netw tasks while blocked for IO (prevents ESP watchdog trigger)
+  }
+
+  // Check CRC with the number of bytes read
+  if (!checkCRC(resp, index)) {
+    return 0;
+  }
+
+  return index;
+}
+
+/*!
+ * PZEM017v1::checkCRC
+ *
+ * Performs CRC check of the buffer up to len-2 and compares check sum to last two bytes
+ *
+ * @param[in] data Memory buffer containing the frame to check
+ * @param[in] len  Length of the respBuffer including 2 bytes for CRC
+ *
+ * @return is the buffer check sum valid
+ */
+bool PZEM017v1::checkCRC(const uint8_t* buf, uint16_t len) {
+  if (len <= 2)  // Sanity check
+    return false;
+
+  uint16_t crc = CRC16(buf, len - 2);  // Compute CRC of data
+  return ((uint16_t)buf[len - 2] | (uint16_t)buf[len - 1] << 8) == crc;
+}
+
+/*!
+ * PZEM017v1::setCRC
+ *
+ * Set last two bytes of buffer to CRC16 of the buffer up to byte len-2
+ * Buffer must be able to hold at least 3 bytes
+ *
+ * @param[out] data Memory buffer containing the frame to checksum and write CRC to
+ * @param[in] len  Length of the respBuffer including 2 bytes for CRC
+ *
+ */
+void PZEM017v1::setCRC(uint8_t* buf, uint16_t len) {
+  if (len <= 2)  // Sanity check
+    return;
+
+  uint16_t crc = CRC16(buf, len - 2);  // CRC of data
+
+  // Write high and low byte to last two positions
+  buf[len - 2] = crc & 0xFF;         // Low byte first
+  buf[len - 1] = (crc >> 8) & 0xFF;  // High byte second
+}
+
+// Pre computed CRC table
+static const uint16_t crcTable[] PROGMEM = {
+    0X0000, 0XC0C1, 0XC181, 0X0140, 0XC301, 0X03C0, 0X0280, 0XC241,
+    0XC601, 0X06C0, 0X0780, 0XC741, 0X0500, 0XC5C1, 0XC481, 0X0440,
+    0XCC01, 0X0CC0, 0X0D80, 0XCD41, 0X0F00, 0XCFC1, 0XCE81, 0X0E40,
+    0X0A00, 0XCAC1, 0XCB81, 0X0B40, 0XC901, 0X09C0, 0X0880, 0XC841,
+    0XD801, 0X18C0, 0X1980, 0XD941, 0X1B00, 0XDBC1, 0XDA81, 0X1A40,
+    0X1E00, 0XDEC1, 0XDF81, 0X1F40, 0XDD01, 0X1DC0, 0X1C80, 0XDC41,
+    0X1400, 0XD4C1, 0XD581, 0X1540, 0XD701, 0X17C0, 0X1680, 0XD641,
+    0XD201, 0X12C0, 0X1380, 0XD341, 0X1100, 0XD1C1, 0XD081, 0X1040,
+    0XF001, 0X30C0, 0X3180, 0XF141, 0X3300, 0XF3C1, 0XF281, 0X3240,
+    0X3600, 0XF6C1, 0XF781, 0X3740, 0XF501, 0X35C0, 0X3480, 0XF441,
+    0X3C00, 0XFCC1, 0XFD81, 0X3D40, 0XFF01, 0X3FC0, 0X3E80, 0XFE41,
+    0XFA01, 0X3AC0, 0X3B80, 0XFB41, 0X3900, 0XF9C1, 0XF881, 0X3840,
+    0X2800, 0XE8C1, 0XE981, 0X2940, 0XEB01, 0X2BC0, 0X2A80, 0XEA41,
+    0XEE01, 0X2EC0, 0X2F80, 0XEF41, 0X2D00, 0XEDC1, 0XEC81, 0X2C40,
+    0XE401, 0X24C0, 0X2580, 0XE541, 0X2700, 0XE7C1, 0XE681, 0X2640,
+    0X2200, 0XE2C1, 0XE381, 0X2340, 0XE101, 0X21C0, 0X2080, 0XE041,
+    0XA001, 0X60C0, 0X6180, 0XA141, 0X6300, 0XA3C1, 0XA281, 0X6240,
+    0X6600, 0XA6C1, 0XA781, 0X6740, 0XA501, 0X65C0, 0X6480, 0XA441,
+    0X6C00, 0XACC1, 0XAD81, 0X6D40, 0XAF01, 0X6FC0, 0X6E80, 0XAE41,
+    0XAA01, 0X6AC0, 0X6B80, 0XAB41, 0X6900, 0XA9C1, 0XA881, 0X6840,
+    0X7800, 0XB8C1, 0XB981, 0X7940, 0XBB01, 0X7BC0, 0X7A80, 0XBA41,
+    0XBE01, 0X7EC0, 0X7F80, 0XBF41, 0X7D00, 0XBDC1, 0XBC81, 0X7C40,
+    0XB401, 0X74C0, 0X7580, 0XB541, 0X7700, 0XB7C1, 0XB681, 0X7640,
+    0X7200, 0XB2C1, 0XB381, 0X7340, 0XB101, 0X71C0, 0X7080, 0XB041,
+    0X5000, 0X90C1, 0X9181, 0X5140, 0X9301, 0X53C0, 0X5280, 0X9241,
+    0X9601, 0X56C0, 0X5780, 0X9741, 0X5500, 0X95C1, 0X9481, 0X5440,
+    0X9C01, 0X5CC0, 0X5D80, 0X9D41, 0X5F00, 0X9FC1, 0X9E81, 0X5E40,
+    0X5A00, 0X9AC1, 0X9B81, 0X5B40, 0X9901, 0X59C0, 0X5880, 0X9841,
+    0X8801, 0X48C0, 0X4980, 0X8941, 0X4B00, 0X8BC1, 0X8A81, 0X4A40,
+    0X4E00, 0X8EC1, 0X8F81, 0X4F40, 0X8D01, 0X4DC0, 0X4C80, 0X8C41,
+    0X4400, 0X84C1, 0X8581, 0X4540, 0X8701, 0X47C0, 0X4680, 0X8641,
+    0X8201, 0X42C0, 0X4380, 0X8341, 0X4100, 0X81C1, 0X8081, 0X4040};
+
+/*!
+ * PZEM017v1::CRC16
+ *
+ * Calculate the CRC16-Modbus for a buffer
+ * Based on https://www.modbustools.com/modbus_crc16.html
+ *
+ * @param[in] data Memory buffer containing the data to checksum
+ * @param[in] len  Length of the respBuffer
+ *
+ * @return Calculated CRC
+ */
+uint16_t PZEM017v1::CRC16(const uint8_t* data, uint16_t len) {
+  uint8_t nTemp;          // CRC table index
+  uint16_t crc = 0xFFFF;  // Default value
+
+  while (len--) {
+    nTemp = *data++ ^ crc;
+    crc >>= 8;
+    crc ^= (uint16_t)pgm_read_word(&crcTable[nTemp]);
+  }
+  return crc;
+}
+
+/*!
+ * PZEM017v1::search
+ *
+ * Search for available devices. This should be used only for debugging!
+ * Prints any found device addresses on the bus.
+ * Can be disabled by defining PZEM017_DISABLE_SEARCH
+ */
+void PZEM017v1::search() {
+#if (not defined(PZEM017_DISABLE_SEARCH))
+  static uint8_t response[7];
+  for (uint16_t addr = 0x01; addr <= 0xF8; addr++) {
+    // Serial.println(addr);
+    sendCmd8(CMD_RIR, 0x00, 0x01, false, addr);
+
+    if (recieve(response, 7) != 7) {  // Something went wrong
+      continue;
+    } else {
+      Serial.print("Device on addr: ");
+      Serial.print(addr);
+    }
+  }
+#endif
+}

--- a/lib/PZEM-017-v1/PZEM017v1.h
+++ b/lib/PZEM-017-v1/PZEM017v1.h
@@ -1,0 +1,138 @@
+/*
+
+Copyright (c) 2020 Maxz Maxzerker (for PZEM-017)
+Copyright (c) 2019 Jakub Mandula
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+/*
+ * PZEM-004Tv30.h
+ *
+ * Interface library for the upgraded version of PZEM-004T v3.0
+ * Based on the PZEM004T library by @olehs https://github.com/olehs/PZEM004T
+ *
+ * Author: Jakub Mandula https://github.com/mandulaj
+ *
+ *
+ */
+
+/*
+ * PZEM-017Tv1.h
+ *
+ * Interface library for PZEM-017 v1.0
+ * Based on the PZEM004T library by Jakub Mandula https://github.com/mandulaj
+ *
+ * Author: Maxz Maxzerker https://github.com/maxzerker
+ *
+ *
+ */
+
+#ifndef PZEM017v1_H
+#define PZEM017v1_H
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#else
+#include "WProgram.h"
+#endif
+
+// #define PZEM004_NO_SWSERIAL
+#if (not defined(PZEM004_NO_SWSERIAL)) && (defined(__AVR__) || defined(ESP8266) && (not defined(ESP32)))
+#define PZEM004_SOFTSERIAL
+#endif
+
+#if defined(PZEM004_SOFTSERIAL)
+#include <SoftwareSerial.h>
+#endif
+
+#define PZEM017_DEFAULT_ADDR 0x01
+
+class PZEM017v1 {
+ public:
+#if defined(PZEM004_SOFTSERIAL)
+  PZEM017v1(SoftwareSerial& port, uint8_t addr = PZEM017_DEFAULT_ADDR);
+#endif
+  PZEM017v1(HardwareSerial* port, uint8_t addr = PZEM017_DEFAULT_ADDR);
+  ~PZEM017v1();
+
+  float voltage();
+  float current();
+  float power();
+  float energy();
+
+  bool getParameters();
+  float getHighvoltAlarmValue();
+  float getLowvoltAlarmValue();
+  uint16_t getHoldingAddress();
+  uint16_t getShunttype();
+
+  bool setAddress(uint8_t addr);
+  uint8_t getAddress();
+
+  bool setHighvoltAlarm(uint16_t volts);
+  bool isHighvoltAlarmOn();
+
+  bool setLowvoltAlarm(uint16_t volts);
+  bool isLowvoltAlarmOn();
+
+  bool setShuntType(uint16_t type);
+
+  bool resetEnergy();
+
+  void search();
+
+ private:
+  Stream* _serial;  // Serial interface
+  bool _isSoft;     // Is serial interface software
+
+  uint8_t _addr;  // Device address
+
+  struct {
+    float voltage;
+    float current;
+    float power;
+    float energy;
+    uint16_t HVAlarms;
+    uint16_t LVAlarms;
+  } _currentValues;  // Measured values
+
+  struct {
+    float HVAlarmVoltage;
+    float LVAlarmVoltage;
+    uint16_t address;
+    uint16_t shunttype;
+  } _parameterValues;  // Parameter values
+
+  uint64_t _lastInputRead;    // Last time input values were updated
+  uint64_t _lastHoldingRead;  // Last time input values were updated
+
+  void init(uint8_t addr);  // Init common to all constructors
+
+  bool updateValues();                            // Get most up to date values from device registers and cache them
+  uint16_t recieve(uint8_t* resp, uint16_t len);  // Receive len bytes into a buffer
+
+  bool sendCmd8(uint8_t cmd, uint16_t rAddr, uint16_t val, bool check = false, uint16_t slave_addr = 0xFFFF);  // Send 8 byte command
+
+  void setCRC(uint8_t* buf, uint16_t len);          // Set the CRC for a buffer
+  bool checkCRC(const uint8_t* buf, uint16_t len);  // Check CRC of buffer
+
+  uint16_t CRC16(const uint8_t* data, uint16_t len);  // Calculate CRC of buffer
+};
+
+#endif  // PZEM017_H

--- a/lib/PZEM-017-v1/README.md
+++ b/lib/PZEM-017-v1/README.md
@@ -1,0 +1,61 @@
+# PZEM-017 v1.0
+Arduino communication library for Peacefair PZEM-017 v1.0 Energy monitor, a slightly modify version of Jakub Mandula's PZEM-004T-v30 library (https://github.com/mandulaj/PZEM-004T-v30)
+
+***
+
+#### Common issue:
+Make sure the device is connected to the 5v power!
+
+### Example
+```c++
+#include <PZEM017v1.h>
+
+/* Use software serial for the PZEM
+ * Pin 4 Rx (Connects to the Tx pin on the PZEM)
+ * Pin 5 Tx (Connects to the Rx pin on the PZEM)
+*/
+PZEM017v1 pzem(4, 5); //WMOS D1 4=D1, 5=D2
+
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+    float voltage = pzem.voltage();
+    if( !isnan(voltage) ){
+        Serial.print("Voltage: "); Serial.print(voltage); Serial.println("V");
+    } else {
+        Serial.println("Error reading voltage");
+    }
+
+    float current = pzem.current();
+    if( !isnan(current) ){
+        Serial.print("Current: "); Serial.print(current); Serial.println("A");
+    } else {
+        Serial.println("Error reading current");
+    }
+
+    float power = pzem.power();
+    if( !isnan(power) ){
+        Serial.print("Power: "); Serial.print(power); Serial.println("W");
+    } else {
+        Serial.println("Error reading power");
+    }
+
+    float energy = pzem.energy();
+    if( !isnan(energy) ){
+        Serial.print("Energy: "); Serial.print(energy,3); Serial.println("kWh");
+    } else {
+        Serial.println("Error reading energy");
+    }
+
+    Serial.println();
+    delay(2000);
+}
+
+```
+# Installation instructions
+You should be able to install the library from the Library Manager in the Arduino IDE. You can also download the ZIP of this repository and install it manually. A guide on how to do that is over here: [https://www.arduino.cc/en/guide/libraries](https://www.arduino.cc/en/guide/libraries) 
+
+***
+Thank you to [@olehs](https://github.com/olehs) and [Jakub Mandula](https://github.com/mandulaj) for this great library.

--- a/lib/PZEM-017-v1/examples/PZEMChangeAddress/PZEMChangeAddress.ino
+++ b/lib/PZEM-017-v1/examples/PZEMChangeAddress/PZEMChangeAddress.ino
@@ -1,0 +1,21 @@
+#include <PZEM017v1.h>
+
+PZEM017v1 pzem(&Serial3);
+
+void setup() {
+  Serial.begin(115200);
+}
+
+uint8_t addr = 0x01;
+
+void loop() {
+    pzem.setAddress(addr);
+    Serial.print("Current address:");
+    Serial.println(pzem.getAddress());
+    Serial.println();
+
+    if(++addr == 0xF8)
+        addr = 0x01;
+
+    delay(1000);
+}

--- a/lib/PZEM-017-v1/examples/PZEMHardSerial/PZEMHardSerial.ino
+++ b/lib/PZEM-017-v1/examples/PZEMHardSerial/PZEMHardSerial.ino
@@ -1,0 +1,43 @@
+#include <PZEM017v1.h>
+
+/* Hardware Serial3 is only available on certain boards.
+ * For example the Arduino MEGA 2560
+*/
+PZEM017v1 pzem(&Serial3);
+
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+    float voltage = pzem.voltage();
+    if(!isnan(voltage)){
+        Serial.print("Voltage: "); Serial.print(voltage); Serial.println("V");
+    } else {
+        Serial.println("Error reading voltage");
+    }
+
+    float current = pzem.current();
+    if(!isnan(current)){
+        Serial.print("Current: "); Serial.print(current); Serial.println("A");
+    } else {
+        Serial.println("Error reading current");
+    }
+
+    float power = pzem.power();
+    if(!isnan(power)){
+        Serial.print("Power: "); Serial.print(power); Serial.println("W");
+    } else {
+        Serial.println("Error reading power");
+    }
+
+    float energy = pzem.energy();
+    if(!isnan(energy)){
+        Serial.print("Energy: "); Serial.print(energy,3); Serial.println("kWh");
+    } else {
+        Serial.println("Error reading energy");
+    }
+
+    Serial.println();
+    delay(2000);
+}

--- a/lib/PZEM-017-v1/examples/PZEMSoftwareSerial/PZEMSoftwareSerial.ino
+++ b/lib/PZEM-017-v1/examples/PZEMSoftwareSerial/PZEMSoftwareSerial.ino
@@ -1,0 +1,44 @@
+#include <PZEM017v1.h>
+
+/* Use software serial for the PZEM
+ * Pin 4 Rx (Connects to the Tx pin on the PZEM)
+ * Pin 5 Tx (Connects to the Rx pin on the PZEM)
+*/
+PZEM017v1 pzem(4, 5); //WMOS D1 4=D1, 5=D2
+
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+    float voltage = pzem.voltage();
+    if( !isnan(voltage) ){
+        Serial.print("Voltage: "); Serial.print(voltage); Serial.println("V");
+    } else {
+        Serial.println("Error reading voltage");
+    }
+
+    float current = pzem.current();
+    if( !isnan(current) ){
+        Serial.print("Current: "); Serial.print(current); Serial.println("A");
+    } else {
+        Serial.println("Error reading current");
+    }
+
+    float power = pzem.power();
+    if( !isnan(power) ){
+        Serial.print("Power: "); Serial.print(power); Serial.println("W");
+    } else {
+        Serial.println("Error reading power");
+    }
+
+    float energy = pzem.energy();
+    if( !isnan(energy) ){
+        Serial.print("Energy: "); Serial.print(energy,3); Serial.println("kWh");
+    } else {
+        Serial.println("Error reading energy");
+    }
+
+    Serial.println();
+    delay(2000);
+}

--- a/lib/PZEM-017-v1/library.json
+++ b/lib/PZEM-017-v1/library.json
@@ -1,0 +1,25 @@
+{
+    "name": "PZEM-017-v1",
+    "frameworks": "arduino",
+    "keywords": "peacefair, pzem, powermeter, v1",
+    "description": "Enables communication to Peacefair PZEM-017 v1.0 Power and Energy monitor",
+    "url": "https://github.com/maxzerker/PZEM-017-v1",
+    "authors": [
+        {
+            "name": "Maxzerker Maxz"
+        }
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/maxzerker/PZEM-017-v1"
+    },
+    "platforms": "*",
+    "version": "1.0.0",
+    "dependencies": [
+        {
+            "name": "EspSoftwareSerial",
+            "version": ">=3.2.0",
+            "platforms": "espressif8266"
+        }
+    ]
+}

--- a/lib/PZEM-017-v1/library.properties
+++ b/lib/PZEM-017-v1/library.properties
@@ -1,0 +1,9 @@
+name=PZEM-017-v1
+version=1.0.0
+author=Maxzerker Maxz
+maintainer=
+sentence=Enables communication to Peacefair PZEM-017 v1.0 Power and Energy monitor
+paragraph=
+category=Sensors
+url=https://github.com/maxzerker/PZEM-017-v1
+architectures=*

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,4 +34,4 @@ build_flags =
 	'-D AC_OUTPUT_PZEM_ADDRESS=${secrets.ac_output_pzem_address}'
 	'-D DC_PZEM_RX_PIN=${secrets.dc_pzem_rx_pin}'
 	'-D DC_PZEM_TX_PIN=${secrets.dc_pzem_tx_pin}'
-  '-D DC_BATTERY_OUTPUT_PZEM_ADDRESS=${secrets.dc_battery_output_pzem_address}'
+	'-D DC_BATTERY_OUTPUT_PZEM_ADDRESS=${secrets.dc_battery_output_pzem_address}'

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,3 +32,6 @@ build_flags =
 	'-D AC_PZEM_TX_PIN=${secrets.ac_pzem_tx_pin}'
 	'-D AC_INPUT_PZEM_ADDRESS=${secrets.ac_input_pzem_address}'
 	'-D AC_OUTPUT_PZEM_ADDRESS=${secrets.ac_output_pzem_address}'
+	'-D DC_PZEM_RX_PIN=${secrets.dc_pzem_rx_pin}'
+	'-D DC_PZEM_TX_PIN=${secrets.dc_pzem_tx_pin}'
+  '-D DC_BATTERY_OUTPUT_PZEM_ADDRESS=${secrets.dc_battery_output_pzem_address}'

--- a/secrets.ini.template
+++ b/secrets.ini.template
@@ -17,3 +17,6 @@ ac_pzem_rx_pin=1
 ac_pzem_tx_pin=2
 ac_input_pzem_address=0x01
 ac_output_pzem_address=0x02
+dc_pzem_rx_pin=3
+dc_pzem_tx_pin=4
+dc_battery_output_pzem_address=0x03

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -156,7 +156,7 @@ String getPzemsPayload() {
 
   doc[F("acInput")] = acInPzem.getValues(date);
   doc[F("acOutput")] = acOutPzem.getValues(date);
-  doc[F("dcBatteryOutput")] = dcBattOutPzem.getValues();
+  doc[F("dcBatteryOutput")] = dcBattOutPzem.getValues(date);
 
   serializeJson(doc, payload);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "websocket/websocket.h"
 
 void setup() {
+  // Serial.begin(74880);
   Serial.begin(115200);
   Serial.println();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,6 @@
 #include "websocket/websocket.h"
 
 void setup() {
-  // Serial.begin(74880);
   Serial.begin(115200);
   Serial.println();
 

--- a/src/pzems/acpzem.cpp
+++ b/src/pzems/acpzem.cpp
@@ -6,6 +6,16 @@ AcPzem::AcPzem(SoftwareSerial& port, uint8_t addr)
     : _pzem(port, addr), _zone{0.0, 0.0, 0.0, 0.0} {
 }
 
+JsonDocument AcPzem::getStatus() {
+  JsonDocument doc;
+
+  doc[F("isConnected")] = !isnan(_pzem.voltage());
+  doc[F("currentAddress")] = _pzem.getAddress();
+  doc[F("savedAddress")] = _pzem.readAddress();
+
+  return doc;
+}
+
 JsonDocument AcPzem::getValues(const Date& date) {
   JsonDocument doc;
 

--- a/src/pzems/acpzem.cpp
+++ b/src/pzems/acpzem.cpp
@@ -3,7 +3,8 @@
 // Public
 
 AcPzem::AcPzem(SoftwareSerial& port, uint8_t addr)
-    : _pzem(port, addr), _zone{0.0, 0.0, 0.0, 0.0} {
+    : _pzem(port, addr) {
+  _zone = {0.0, 0.0, 0.0, 0.0};
 }
 
 JsonDocument AcPzem::getStatus() {
@@ -104,78 +105,4 @@ void AcPzem::readValues() {
   _powerFactor = _pzem.pf();
 
   calcZoneEnergy();
-}
-
-void AcPzem::calcZoneEnergy() {
-  float t1Energy;
-  float t2Energy;
-
-  if (isT1ZoneActive(_createdAt.hour)) {
-    t1Energy = calcT1ZoneEnergy();
-    t2Energy = _zone.t2EnergyAcc;
-  } else {
-    t1Energy = _zone.t1EnergyAcc;
-    t2Energy = calcT2ZoneEnergy();
-  }
-
-  _t1Energy = t1Energy;
-  _t2Energy = t2Energy;
-}
-
-float AcPzem::calcT1ZoneEnergy() {
-  bool isStartOfZone =
-      isStartOfT1Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
-  bool isEndOfZone =
-      isEndOfT1Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
-
-  if (!_zone.t1StartEnergy || isStartOfZone) {
-    _zone.t1StartEnergy = _energy;
-  }
-
-  float t1Energy = _energy - _zone.t1StartEnergy + _zone.t1EnergyAcc;
-
-  if (isEndOfZone) {
-    _zone.t1EnergyAcc = t1Energy;
-  }
-
-  return t1Energy;
-}
-
-float AcPzem::calcT2ZoneEnergy() {
-  bool isStartOfZone =
-      isStartOfT2Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
-  bool isEndOfZone =
-      isEndOfT2Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
-
-  if (!_zone.t2StartEnergy || isStartOfZone) {
-    _zone.t2StartEnergy = _energy;
-  }
-
-  float t2Energy = _energy - _zone.t2StartEnergy + _zone.t2EnergyAcc;
-
-  if (isEndOfZone) {
-    _zone.t2EnergyAcc = t2Energy;
-  }
-
-  return t2Energy;
-}
-
-bool AcPzem::isT1ZoneActive(uint8_t hour) {
-  return hour >= 7 && hour < 23;
-}
-
-bool AcPzem::isStartOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second) {
-  return hour == 7 && minute == 0 && second == 0;
-}
-
-bool AcPzem::isEndOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second) {
-  return hour == 22 && minute == 59 && second == 59;
-}
-
-bool AcPzem::isStartOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second) {
-  return hour == 23 && minute == 0 && second == 0;
-}
-
-bool AcPzem::isEndOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second) {
-  return hour == 6 && minute == 59 && second == 59;
 }

--- a/src/pzems/dcpzem.cpp
+++ b/src/pzems/dcpzem.cpp
@@ -1,0 +1,84 @@
+#include "pzems/dcpzem.h"
+
+// Public
+
+DcPzem::DcPzem(SoftwareSerial& port, uint8_t addr)
+    : _pzem(port, addr) {
+}
+
+JsonDocument DcPzem::getStatus() {
+  JsonDocument doc;
+
+  doc[F("isConnected")] = !isnan(_pzem.voltage());
+  doc[F("address")] = _pzem.getAddress();
+  doc[F("holdingAddress")] = _pzem.getHoldingAddress();
+  doc[F("shuntType")] = _pzem.getShunttype();
+
+  return doc;
+}
+
+JsonDocument DcPzem::getValues() {
+  JsonDocument doc;
+
+  readValues();
+
+  if (_voltage) {
+    doc[F("voltageV")] = _voltage;
+  }
+
+  if (_current) {
+    doc[F("currentA")] = _current;
+  }
+
+  if (_power) {
+    doc[F("powerKw")] = _power;
+  }
+
+  if (_energy) {
+    doc[F("energyKwh")] = _energy;
+  }
+
+  return doc;
+}
+
+JsonDocument DcPzem::changeAddress(uint8_t addr) {
+  JsonDocument doc;
+
+  doc[F("addressToSet")] = addr;
+  doc[F("isChanged")] = _pzem.setAddress(addr);
+
+  return doc;
+}
+
+JsonDocument DcPzem::changeShuntType(uint16_t type) {
+  JsonDocument doc;
+
+  doc[F("shuntToSet")] = type;
+  doc[F("isChanged")] = _pzem.setShuntType(type);
+
+  return doc;
+}
+
+void DcPzem::resetCounter() {
+  _pzem.resetEnergy();
+}
+
+// Private
+
+void DcPzem::readValues() {
+  _voltage = _pzem.voltage();
+
+  // If sensor is disconnected - clear values and skip further sensor polling
+  if (isnan(_voltage)) {
+    _voltage = 0.0;
+    _current = 0.0;
+    _power = 0.0;
+    _energy = 0.0;
+
+    return;
+  }
+
+  _current = _pzem.current();
+  _power = _pzem.power() / 1000.0;
+  _energy = _pzem.energy();
+}

--- a/src/pzems/dcpzem.cpp
+++ b/src/pzems/dcpzem.cpp
@@ -4,6 +4,7 @@
 
 DcPzem::DcPzem(SoftwareSerial& port, uint8_t addr)
     : _pzem(port, addr) {
+  _zone = {0.0, 0.0, 0.0, 0.0};
 }
 
 JsonDocument DcPzem::getStatus() {
@@ -17,8 +18,10 @@ JsonDocument DcPzem::getStatus() {
   return doc;
 }
 
-JsonDocument DcPzem::getValues() {
+JsonDocument DcPzem::getValues(const Date& date) {
   JsonDocument doc;
+
+  _createdAt = date;
 
   readValues();
 
@@ -61,6 +64,11 @@ JsonDocument DcPzem::changeShuntType(uint16_t type) {
 
 void DcPzem::resetCounter() {
   _pzem.resetEnergy();
+
+  _zone.t1StartEnergy = 0.0;
+  _zone.t2StartEnergy = 0.0;
+  _zone.t1EnergyAcc = 0.0;
+  _zone.t2EnergyAcc = 0.0;
 }
 
 // Private
@@ -81,4 +89,6 @@ void DcPzem::readValues() {
   _current = _pzem.current();
   _power = _pzem.power() / 1000.0;
   _energy = _pzem.energy();
+
+  calcZoneEnergy();
 }

--- a/src/pzems/pzem.cpp
+++ b/src/pzems/pzem.cpp
@@ -1,0 +1,77 @@
+#include "pzems/pzem.h"
+
+// Protected
+
+void Pzem::calcZoneEnergy() {
+  float t1Energy;
+  float t2Energy;
+
+  if (isT1ZoneActive(_createdAt.hour)) {
+    t1Energy = calcT1ZoneEnergy();
+    t2Energy = _zone.t2EnergyAcc;
+  } else {
+    t1Energy = _zone.t1EnergyAcc;
+    t2Energy = calcT2ZoneEnergy();
+  }
+
+  _t1Energy = t1Energy;
+  _t2Energy = t2Energy;
+}
+
+float Pzem::calcT1ZoneEnergy() {
+  bool isStartOfZone =
+      isStartOfT1Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
+  bool isEndOfZone =
+      isEndOfT1Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
+
+  if (!_zone.t1StartEnergy || isStartOfZone) {
+    _zone.t1StartEnergy = _energy;
+  }
+
+  float t1Energy = _energy - _zone.t1StartEnergy + _zone.t1EnergyAcc;
+
+  if (isEndOfZone) {
+    _zone.t1EnergyAcc = t1Energy;
+  }
+
+  return t1Energy;
+}
+
+float Pzem::calcT2ZoneEnergy() {
+  bool isStartOfZone =
+      isStartOfT2Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
+  bool isEndOfZone =
+      isEndOfT2Zone(_createdAt.hour, _createdAt.minute, _createdAt.second);
+
+  if (!_zone.t2StartEnergy || isStartOfZone) {
+    _zone.t2StartEnergy = _energy;
+  }
+
+  float t2Energy = _energy - _zone.t2StartEnergy + _zone.t2EnergyAcc;
+
+  if (isEndOfZone) {
+    _zone.t2EnergyAcc = t2Energy;
+  }
+
+  return t2Energy;
+}
+
+bool Pzem::isT1ZoneActive(uint8_t hour) {
+  return hour >= 7 && hour < 23;
+}
+
+bool Pzem::isStartOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second) {
+  return hour == 7 && minute == 0 && second == 0;
+}
+
+bool Pzem::isEndOfT1Zone(uint8_t hour, uint8_t minute, uint8_t second) {
+  return hour == 22 && minute == 59 && second == 59;
+}
+
+bool Pzem::isStartOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second) {
+  return hour == 23 && minute == 0 && second == 0;
+}
+
+bool Pzem::isEndOfT2Zone(uint8_t hour, uint8_t minute, uint8_t second) {
+  return hour == 6 && minute == 59 && second == 59;
+}


### PR DESCRIPTION
## Description

- Add PZEM-017 sensor support
- Add debug endpoint GET `/pzems/status` to show connection info for all PZEMs
- Add PATCH `/pzems/shunt` to setting particular shunt type for particular DC PZEM

- Fix compatibility issues in the `PZEM017v1` library:
   - Rename the `PZEM_DEFAULT_ADDR` constant to `PZEM017_DEFAULT_ADDR`, since it conflicts with `PZEM004Tv30` library
   - Add an additional constructor which takes the instance of the `SoftwareSerial` class, to maintain several PZEMs on one bus

## After

<img width="529" alt="image" src="https://github.com/user-attachments/assets/76bcaa2e-2627-450c-9056-e1674772c826">

<img width="617" alt="image" src="https://github.com/user-attachments/assets/e5b2895c-f731-458a-8071-982cd2e9976a">
