### PR TITLE
SC-32: The createdAtGmt field was sent with the current timezone instead of UTC in ISO format

### DIFF
--- a/include/utils/date.h
+++ b/include/utils/date.h
@@ -4,23 +4,24 @@
 
 #include <Arduino.h>
 #include <GyverNTP.h>
+#include <Timezone.h>
 
 struct Date {
-  uint16_t year;
-  uint8_t month;
-  uint8_t day;
-  uint8_t hour;
-  uint8_t minute;
-  uint8_t second;
+  int year;
+  int month;
+  int day;
+  int hour;
+  int minute;
+  int second;
   uint16_t ms;
 };
 
 void startNTP();
-bool forceUpdate();
 void tickNTP();
 
-Date getDate();
+Date getUTCDate();
+Date getLocalDate();
 
-String toISODateString(const Date& date);
+String toJSON(const Date& date);
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,12 +22,12 @@ lib_deps =
 	plerup/EspSoftwareSerial@^8.2.0
 	mandulaj/PZEM-004T-v30@^1.1.2
 	links2004/WebSockets@^2.5.2
+	jchristensen/Timezone@^1.2.4
 build_flags = 
 	'-D WIFI_SSID=${secrets.wifi_ssid}'
 	'-D WIFI_PWD=${secrets.wifi_pwd}'
 	'-D ESP_DOMAIN_NAME=${secrets.esp_domain_name}'
 	'-D BROADCAST_INTERVAL=${secrets.broadcast_interval}'
-	'-D TIMEZONE_OFFSET=${secrets.timezone_offset}'
 	'-D AC_PZEM_RX_PIN=${secrets.ac_pzem_rx_pin}'
 	'-D AC_PZEM_TX_PIN=${secrets.ac_pzem_tx_pin}'
 	'-D AC_INPUT_PZEM_ADDRESS=${secrets.ac_input_pzem_address}'

--- a/secrets.ini.template
+++ b/secrets.ini.template
@@ -9,9 +9,6 @@ esp_domain_name="esp8266"
 ; Websocket
 broadcast_interval=1000
 
-; NTP
-timezone_offset=0
-
 ; Sensors
 ac_pzem_rx_pin=1
 ac_pzem_tx_pin=2

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -150,9 +150,9 @@ String getPzemsPayload() {
   JsonDocument doc;
   String payload;
 
-  Date date = getDate();
+  Date date = getLocalDate();
 
-  doc[F("createdAtGmt")] = toISODateString(date);
+  doc[F("createdAtGmt")] = toJSON(getUTCDate());
 
   doc[F("acInput")] = acInPzem.getValues(date);
   doc[F("acOutput")] = acOutPzem.getValues(date);
@@ -167,7 +167,8 @@ String getPzemsStatus() {
   JsonDocument doc;
   String payload;
 
-  doc[F("createdAtGmt")] = toISODateString(getDate());
+  doc[F("createdAtGmt")] = toJSON(getUTCDate());
+  doc[F("createdAt")] = toJSON(getLocalDate());
 
   doc[F("acInput")] = acInPzem.getStatus();
   doc[F("acOutput")] = acOutPzem.getStatus();


### PR DESCRIPTION
## Description

To calculate the energy for zones T1 and T2, ESP must rely on the current date obtained by the current time zone in the region. Hence, there is a bug since the formatted date is included in the response in ISO format but not in UTC time zone, but rather in the current one. Therefore, local time should be used to calculate the energy, but the ISO date should be returned in UTC in the API.

- The Timezone library was used to convert the UTC timestamp to the local time zone. The UTC time is obtained through the NTP protocol.
- The library also allows control of the change from winter time to summer time, and vice versa (DST).

## Before

<img width="802" alt="image" src="https://github.com/user-attachments/assets/846b0603-fc8b-4438-a5b1-07df2654e373">

## After

<img width="898" alt="image" src="https://github.com/user-attachments/assets/925b36eb-b72b-4d6c-b904-ba68d0b91847">
