### PR TITLE
SC-37: Multiply PZEM-017 sensors on one bus

### DIFF
--- a/include/pzems/pzem.h
+++ b/include/pzems/pzem.h
@@ -8,7 +8,8 @@
 
 #define AC_INPUT_PZEM_ID "acInput"
 #define AC_OUTPUT_PZEM_ID "acOutput"
-#define DC_BATTERY_OUTPUT_PZEM_ID "dcBatteryOutput"
+#define DC_BATTERY_PZEM_ID "dcBattery"
+#define DC_SUN_PZEM_ID "dcSun"
 
 void startPzems();
 

--- a/lib/PZEM-017-v1/PZEM017v1.cpp
+++ b/lib/PZEM-017-v1/PZEM017v1.cpp
@@ -81,7 +81,7 @@ void printBuf(uint8_t* buffer, uint16_t len) {
  * @param transmitPin TX pin
  * @param addr Slave address of device
  */
-#if defined(PZEM004_SOFTSERIAL)
+#if defined(PZEM017V1_SOFTSERIAL)
 PZEM017v1::PZEM017v1(SoftwareSerial& port, uint8_t addr) {
   port.begin(PZEM_BAUD_RATE);
 
@@ -210,7 +210,7 @@ bool PZEM017v1::sendCmd8(uint8_t cmd, uint16_t rAddr, uint16_t val, bool check, 
   _serial->write(sendBuffer, 8);  // send frame
 
   if (check) {
-    if (!recieve(respBuffer, 8)) {  // if check enabled, read the response
+    if (!receive(respBuffer, 8)) {  // if check enabled, read the response
       return false;
     }
 
@@ -328,7 +328,7 @@ bool PZEM017v1::getParameters() {
   // Read 3 registers starting at 0x00
   sendCmd8(CMD_RHR, 0x00, 0x04, false);
 
-  if (recieve(response, 13) != 13) {  // Something went wrong
+  if (receive(response, 13) != 13) {  // Something went wrong
     return false;
   }
 
@@ -344,7 +344,7 @@ bool PZEM017v1::getParameters() {
   _parameterValues.address = ((uint32_t)response[7] << 8 |  // Raw address 0x00-0xf7
                               (uint32_t)response[8]);
 
-  _parameterValues.shunttype = ((uint32_t)response[9] << 8 |  // Shunt type 0x0000 - 0x0003 (100A/50A/200A/300A)
+  _parameterValues.shuntType = ((uint32_t)response[9] << 8 |  // Shunt type 0x0000 - 0x0003 (100A/50A/200A/300A)
                                 (uint32_t)response[10]);
   // Record current time as _lastHoldingRead
   _lastHoldingRead = millis();
@@ -398,18 +398,18 @@ uint16_t PZEM017v1::getHoldingAddress() {
 }
 
 /*!
- * PZEM017v1::shunttype
+ * PZEM017v1::shuntType
  *
- * Current shuttype
+ * Current shutType
  *
  *
- * @return device shuttype
+ * @return device shutType
  */
-uint16_t PZEM017v1::getShunttype() {
+uint16_t PZEM017v1::getShuntType() {
   if (!getParameters())
     return NAN;
 
-  return _parameterValues.shunttype;
+  return _parameterValues.shuntType;
 }
 
 /*!
@@ -431,7 +431,7 @@ bool PZEM017v1::updateValues() {
   // Read 10 registers starting at 0x00 (no check)
   sendCmd8(CMD_RIR, 0x00, 0x08, false);
 
-  if (recieve(response, 21) != 21) {  // Something went wrong
+  if (receive(response, 21) != 21) {  // Something went wrong
     return false;
   }
   // Update the current values
@@ -485,7 +485,7 @@ bool PZEM017v1::resetEnergy() {
   setCRC(buffer, 4);
   _serial->write(buffer, 4);
 
-  uint16_t length = recieve(reply, 5);
+  uint16_t length = receive(reply, 5);
 
   if (length == 0 || length == 5) {
     return false;
@@ -579,8 +579,8 @@ bool PZEM017v1::setLowvoltAlarm(uint16_t volts) {
  *
  * @return number of bytes read
  */
-uint16_t PZEM017v1::recieve(uint8_t* resp, uint16_t len) {
-#ifdef PZEM004_SOFTSERIAL
+uint16_t PZEM017v1::receive(uint8_t* resp, uint16_t len) {
+#ifdef PZEM017V1_SOFTSERIAL
   if (_isSoft)
     ((SoftwareSerial*)_serial)->listen();  // Start software serial listen
 #endif
@@ -715,7 +715,7 @@ void PZEM017v1::search() {
     // Serial.println(addr);
     sendCmd8(CMD_RIR, 0x00, 0x01, false, addr);
 
-    if (recieve(response, 7) != 7) {  // Something went wrong
+    if (receive(response, 7) != 7) {  // Something went wrong
       continue;
     } else {
       Serial.print("Device on addr: ");

--- a/lib/PZEM-017-v1/PZEM017v1.h
+++ b/lib/PZEM-017-v1/PZEM017v1.h
@@ -52,12 +52,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "WProgram.h"
 #endif
 
-// #define PZEM004_NO_SWSERIAL
-#if (not defined(PZEM004_NO_SWSERIAL)) && (defined(__AVR__) || defined(ESP8266) && (not defined(ESP32)))
-#define PZEM004_SOFTSERIAL
+// #define PZEM017V1_NO_SWSERIAL
+#if (not defined(PZEM017V1_NO_SWSERIAL)) && (defined(__AVR__) || defined(ESP8266) && (not defined(ESP32)))
+#define PZEM017V1_SOFTSERIAL
 #endif
 
-#if defined(PZEM004_SOFTSERIAL)
+#if defined(PZEM017V1_SOFTSERIAL)
 #include <SoftwareSerial.h>
 #endif
 
@@ -65,7 +65,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 class PZEM017v1 {
  public:
-#if defined(PZEM004_SOFTSERIAL)
+#if defined(PZEM017V1_SOFTSERIAL)
   PZEM017v1(SoftwareSerial& port, uint8_t addr = PZEM017_DEFAULT_ADDR);
 #endif
   PZEM017v1(HardwareSerial* port, uint8_t addr = PZEM017_DEFAULT_ADDR);
@@ -80,7 +80,7 @@ class PZEM017v1 {
   float getHighvoltAlarmValue();
   float getLowvoltAlarmValue();
   uint16_t getHoldingAddress();
-  uint16_t getShunttype();
+  uint16_t getShuntType();
 
   bool setAddress(uint8_t addr);
   uint8_t getAddress();
@@ -116,7 +116,7 @@ class PZEM017v1 {
     float HVAlarmVoltage;
     float LVAlarmVoltage;
     uint16_t address;
-    uint16_t shunttype;
+    uint16_t shuntType;
   } _parameterValues;  // Parameter values
 
   uint64_t _lastInputRead;    // Last time input values were updated
@@ -125,7 +125,7 @@ class PZEM017v1 {
   void init(uint8_t addr);  // Init common to all constructors
 
   bool updateValues();                            // Get most up to date values from device registers and cache them
-  uint16_t recieve(uint8_t* resp, uint16_t len);  // Receive len bytes into a buffer
+  uint16_t receive(uint8_t* resp, uint16_t len);  // Receive len bytes into a buffer
 
   bool sendCmd8(uint8_t cmd, uint16_t rAddr, uint16_t val, bool check = false, uint16_t slave_addr = 0xFFFF);  // Send 8 byte command
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,7 @@ platform = espressif8266
 board = nodemcuv2
 framework = arduino
 monitor_speed = 115200
+monitor_filters = time
 lib_deps = 
 	bblanchon/ArduinoJson@^7.1.0
 	gyverlibs/GyverNTP@^2.0.2
@@ -27,12 +28,15 @@ lib_deps =
 build_flags = 
 	'-D WIFI_SSID=${secrets.wifi_ssid}'
 	'-D WIFI_PWD=${secrets.wifi_pwd}'
+	'-D DEBUG_MODE=${secrets.debug_mode}'
 	'-D ESP_DOMAIN_NAME=${secrets.esp_domain_name}'
 	'-D BROADCAST_INTERVAL=${secrets.broadcast_interval}'
 	'-D AC_PZEM_RX_PIN=${secrets.ac_pzem_rx_pin}'
 	'-D AC_PZEM_TX_PIN=${secrets.ac_pzem_tx_pin}'
 	'-D AC_INPUT_PZEM_ADDRESS=${secrets.ac_input_pzem_address}'
 	'-D AC_OUTPUT_PZEM_ADDRESS=${secrets.ac_output_pzem_address}'
-	'-D DC_PZEM_RX_PIN=${secrets.dc_pzem_rx_pin}'
-	'-D DC_PZEM_TX_PIN=${secrets.dc_pzem_tx_pin}'
-	'-D DC_BATTERY_OUTPUT_PZEM_ADDRESS=${secrets.dc_battery_output_pzem_address}'
+	'-D DC_PZEM_SHARED_TX_PIN=${secrets.dc_pzem_shared_tx_pin}'
+	'-D DC_BATTERY_PZEM_RX_PIN=${secrets.dc_battery_pzem_rx_pin}'
+	'-D DC_SUN_PZEM_RX_PIN=${secrets.dc_sun_pzem_rx_pin}'
+	'-D DC_BATTERY_PZEM_ADDRESS=${secrets.dc_battery_pzem_address}'
+	'-D DC_SUN_PZEM_ADDRESS=${secrets.dc_sun_pzem_address}'

--- a/secrets.ini.template
+++ b/secrets.ini.template
@@ -3,6 +3,9 @@
 wifi_ssid=""
 wifi_pwd=""
 
+; ESP
+debug_mode=0 ; Disable for prod firmware to improve the performance
+
 ; DNS
 esp_domain_name="esp8266"
 
@@ -10,10 +13,15 @@ esp_domain_name="esp8266"
 broadcast_interval=1000
 
 ; Sensors
-ac_pzem_rx_pin=1
-ac_pzem_tx_pin=2
+ac_pzem_rx_pin=D6 ; PZEM's TX pin
+ac_pzem_tx_pin=D4 ; PZEM's RX pin
+
 ac_input_pzem_address=0x01
 ac_output_pzem_address=0x02
-dc_pzem_rx_pin=3
-dc_pzem_tx_pin=4
-dc_battery_output_pzem_address=0x03
+
+dc_pzem_shared_tx_pin=D4 ; PZEM's TX pin
+dc_battery_pzem_rx_pin=D5 ; PZEM's RX pin
+dc_sun_pzem_rx_pin=D7 ; PZEM's RX pin
+
+dc_battery_pzem_address=0x04
+dc_sun_pzem_address=0x03

--- a/src/pzems/pzem.cpp
+++ b/src/pzems/pzem.cpp
@@ -1,19 +1,22 @@
 #include "pzems/pzem.h"
 
 static SoftwareSerial acPzemSerial(AC_PZEM_RX_PIN, AC_PZEM_TX_PIN);
-static SoftwareSerial dcPzemSerial(DC_PZEM_RX_PIN, DC_PZEM_TX_PIN);
+static SoftwareSerial dcBattPzemSerial(DC_BATTERY_PZEM_RX_PIN, DC_PZEM_SHARED_TX_PIN);
+static SoftwareSerial dcSunPzemSerial(DC_SUN_PZEM_RX_PIN, DC_PZEM_SHARED_TX_PIN);
 
-static AcPzem acInPzem(acPzemSerial, 0, AC_INPUT_PZEM_ADDRESS);
-static AcPzem acOutPzem(acPzemSerial, 16, AC_OUTPUT_PZEM_ADDRESS);
+static AcPzem acInputPzem(acPzemSerial, 0, AC_INPUT_PZEM_ADDRESS);
+static AcPzem acOutputPzem(acPzemSerial, 16, AC_OUTPUT_PZEM_ADDRESS);
 
-static DcPzem dcBattOutPzem(dcPzemSerial, 32, DC_BATTERY_OUTPUT_PZEM_ADDRESS);
+static DcPzem dcBatteryPzem(dcBattPzemSerial, 32, DC_BATTERY_PZEM_ADDRESS);
+static DcPzem dcSunPzem(dcSunPzemSerial, 48, DC_SUN_PZEM_ADDRESS);
 
 void startPzems() {
   Serial.println(F("Initializing PZEM zones"));
 
-  acInPzem.startPzem();
-  acOutPzem.startPzem();
-  dcBattOutPzem.startPzem();
+  acInputPzem.startPzem();
+  acOutputPzem.startPzem();
+  dcBatteryPzem.startPzem();
+  dcSunPzem.startPzem();
 }
 
 JsonDocument getPzemsPayload() {
@@ -23,9 +26,10 @@ JsonDocument getPzemsPayload() {
 
   doc[F("createdAtGmt")] = toJSON(getUTCDate());
 
-  doc[F(AC_INPUT_PZEM_ID)] = acInPzem.getValues(date);
-  doc[F(AC_OUTPUT_PZEM_ID)] = acOutPzem.getValues(date);
-  doc[F(DC_BATTERY_OUTPUT_PZEM_ID)] = dcBattOutPzem.getValues(date);
+  doc[F(AC_INPUT_PZEM_ID)] = acInputPzem.getValues(date);
+  doc[F(AC_OUTPUT_PZEM_ID)] = acOutputPzem.getValues(date);
+  doc[F(DC_BATTERY_PZEM_ID)] = dcBatteryPzem.getValues(date);
+  doc[F(DC_SUN_PZEM_ID)] = dcSunPzem.getValues(date);
 
   return doc;
 }
@@ -33,9 +37,10 @@ JsonDocument getPzemsPayload() {
 JsonDocument getPzemsStatus() {
   JsonDocument doc;
 
-  doc[F(AC_INPUT_PZEM_ID)] = acInPzem.getStatus();
-  doc[F(AC_OUTPUT_PZEM_ID)] = acOutPzem.getStatus();
-  doc[F(DC_BATTERY_OUTPUT_PZEM_ID)] = dcBattOutPzem.getStatus();
+  doc[F(AC_INPUT_PZEM_ID)] = acInputPzem.getStatus();
+  doc[F(AC_OUTPUT_PZEM_ID)] = acOutputPzem.getStatus();
+  doc[F(DC_BATTERY_PZEM_ID)] = dcBatteryPzem.getStatus();
+  doc[F(DC_SUN_PZEM_ID)] = dcSunPzem.getStatus();
 
   return doc;
 }
@@ -43,9 +48,10 @@ JsonDocument getPzemsStatus() {
 JsonDocument resetPzemsCounter() {
   JsonDocument doc;
 
-  doc[F(AC_INPUT_PZEM_ID)] = acInPzem.resetCounter();
-  doc[F(AC_OUTPUT_PZEM_ID)] = acOutPzem.resetCounter();
-  doc[F(DC_BATTERY_OUTPUT_PZEM_ID)] = dcBattOutPzem.resetCounter();
+  doc[F(AC_INPUT_PZEM_ID)] = acInputPzem.resetCounter();
+  doc[F(AC_OUTPUT_PZEM_ID)] = acOutputPzem.resetCounter();
+  doc[F(DC_BATTERY_PZEM_ID)] = dcBatteryPzem.resetCounter();
+  doc[F(DC_SUN_PZEM_ID)] = dcSunPzem.resetCounter();
 
   return doc;
 }
@@ -54,11 +60,13 @@ JsonDocument changePzemAddress(String pzemId, uint8_t address) {
   JsonDocument doc;
 
   if (pzemId == F(AC_INPUT_PZEM_ID)) {
-    doc = acInPzem.changeAddress(address);
+    doc = acInputPzem.changeAddress(address);
   } else if (pzemId == F(AC_OUTPUT_PZEM_ID)) {
-    doc = acOutPzem.changeAddress(address);
-  } else if (pzemId == F(DC_BATTERY_OUTPUT_PZEM_ID)) {
-    doc = dcBattOutPzem.changeAddress(address);
+    doc = acOutputPzem.changeAddress(address);
+  } else if (pzemId == F(DC_BATTERY_PZEM_ID)) {
+    doc = dcBatteryPzem.changeAddress(address);
+  } else if (pzemId == F(DC_SUN_PZEM_ID)) {
+    doc = dcSunPzem.changeAddress(address);
   }
 
   return doc;
@@ -67,8 +75,10 @@ JsonDocument changePzemAddress(String pzemId, uint8_t address) {
 JsonDocument changePzemShuntType(String pzemId, uint8_t shuntType) {
   JsonDocument doc;
 
-  if (pzemId == F(DC_BATTERY_OUTPUT_PZEM_ID)) {
-    doc = dcBattOutPzem.changeShuntType(shuntType);
+  if (pzemId == F(DC_BATTERY_PZEM_ID)) {
+    doc = dcBatteryPzem.changeShuntType(shuntType);
+  } else if (pzemId == F(DC_SUN_PZEM_ID)) {
+    doc = dcSunPzem.changeShuntType(shuntType);
   }
 
   return doc;


### PR DESCRIPTION
## Description

- Multiply PZEM-017 sensors on one bus. Unfortunately, the PZEM017, unlike the PZEM004, does not work on the same SoftwareSerial bus. As a workaround to save ESP pins - create separate instances of the SoftwareSerial class and leave the TX pin as common.
- Minor bug fixes:
  - consistency between response field names
  - consistency between PZEM names
  - add missing `t1EnergyKwh`, `t2EnergyKwh` fields to DC PZEM response 
  - typo fixes in the PZEM017 library

Quality of life:
- Add debug mode to config to allow extended logging during development
- Add timestamp to project serial monitor


## After

<img width="888" alt="Screenshot 2024-08-31 at 10 17 09 PM" src="https://github.com/user-attachments/assets/e4e5ed0a-9b54-4a9f-9078-205a4673cda0">

<img width="693" alt="Screenshot 2024-08-31 at 10 17 32 PM" src="https://github.com/user-attachments/assets/556d5d5a-f6ef-44b3-b94b-ffc5adf20cf4">

