### PR TITLE
SC-43: Add WiFi details to the status endpoint

### DIFF
--- a/include/http/server.h
+++ b/include/http/server.h
@@ -7,7 +7,7 @@
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>
 #include "pzems/pzem.h"
-#include "utils/led.h"
+#include "utils/wifi.h"
 
 void startServer();
 void tickServer();

--- a/include/utils/wifi.h
+++ b/include/utils/wifi.h
@@ -3,8 +3,12 @@
 #define WIFI_H
 
 #include <Arduino.h>
+#include <ArduinoJson.h>
 #include <ESP8266WiFi.h>
+#include "utils/led.h"
 
 void connectToWiFi();
+
+JsonDocument getWiFiStatus();
 
 #endif

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -45,6 +45,7 @@ void handleEspStatus() {
   JsonDocument doc;
   String payload;
 
+  doc[F("wifi")] = getWiFiStatus();
   doc[F("date")] = getDateStatus();
   doc[F("pzems")] = getPzemsStatus();
   doc[F("eeprom")] = getEepromStatus();

--- a/src/pzems/pzem.cpp
+++ b/src/pzems/pzem.cpp
@@ -1,13 +1,13 @@
 #include "pzems/pzem.h"
 
 static SoftwareSerial acPzemSerial(AC_PZEM_RX_PIN, AC_PZEM_TX_PIN);
-static SoftwareSerial dcBattPzemSerial(DC_BATTERY_PZEM_RX_PIN, DC_PZEM_SHARED_TX_PIN);
+static SoftwareSerial dcBatteryPzemSerial(DC_BATTERY_PZEM_RX_PIN, DC_PZEM_SHARED_TX_PIN);
 static SoftwareSerial dcSunPzemSerial(DC_SUN_PZEM_RX_PIN, DC_PZEM_SHARED_TX_PIN);
 
 static AcPzem acInputPzem(acPzemSerial, 0, AC_INPUT_PZEM_ADDRESS);
 static AcPzem acOutputPzem(acPzemSerial, 16, AC_OUTPUT_PZEM_ADDRESS);
 
-static DcPzem dcBatteryPzem(dcBattPzemSerial, 32, DC_BATTERY_PZEM_ADDRESS);
+static DcPzem dcBatteryPzem(dcBatteryPzemSerial, 32, DC_BATTERY_PZEM_ADDRESS);
 static DcPzem dcSunPzem(dcSunPzemSerial, 48, DC_SUN_PZEM_ADDRESS);
 
 void startPzems() {

--- a/src/utils/wifi.cpp
+++ b/src/utils/wifi.cpp
@@ -1,5 +1,4 @@
 #include "utils/wifi.h"
-#include "utils/led.h"
 
 void connectToWiFi() {
   Serial.print(F("Connecting to "));
@@ -21,4 +20,13 @@ void connectToWiFi() {
   Serial.println(WIFI_SSID);
   Serial.print(F("Device MAC: "));
   Serial.println(WiFi.macAddress());
+}
+
+JsonDocument getWiFiStatus() {
+  JsonDocument doc;
+
+  doc[F("ip")] = WiFi.localIP().toString();
+  doc[F("mac")] = WiFi.macAddress();
+
+  return doc;
 }


### PR DESCRIPTION
## Description

- Add Wi-Fi IP and MAC address to simplify identifying ESP entry point in the local network

## After

<img width="608" alt="image" src="https://github.com/user-attachments/assets/57b48986-9164-430b-b5c3-9596642c3bc5">
