### PR TITLE
SC-60: Rename PZEM `id` field to the `name` for consistency

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -66,9 +66,9 @@ paths:
       summary: Sets the address to PZEM
       operationId: setPzemAddress
       parameters:
-        - name: id
+        - name: name
           in: query
-          description: ID of the PZEM for which the address is changed
+          description: The name of the PZEM for which the address is changed
           required: true
           schema:
             type: string
@@ -104,7 +104,7 @@ paths:
               schema:
                 type: string
                 examples:
-                  - PZEM with entered "id" is not found
+                  - PZEM with entered name is not found
 
   /pzems/shunt:
     patch:
@@ -113,9 +113,9 @@ paths:
       summary: Sets the shunt type to DC PZEM
       operationId: setPzemShunt
       parameters:
-        - name: id
+        - name: name
           in: query
-          description: ID of the DC PZEM for which the shunt type is changed
+          description: The name of the DC PZEM for which the shunt type is changed
           required: true
           schema:
             type: string
@@ -151,7 +151,7 @@ paths:
               schema:
                 type: string
                 examples:
-                  - PZEM with entered "id" is not found
+                  - PZEM with entered name is not found
   /pzems/counter:
     delete:
       tags:
@@ -227,9 +227,9 @@ components:
     PzemStatus:
       type: object
       properties:
-        id:
+        name:
           type: string
-          description: id of PZEM sensor
+          description: The name of the PZEM sensor
           examples:
             - acInput
         isConnected:
@@ -260,7 +260,7 @@ components:
           examples:
             - 1
       required:
-        - id
+        - name
         - isConnected
         - currentAddress
         - savedAddress
@@ -291,9 +291,9 @@ components:
     Pzem:
       type: object
       properties:
-        id:
+        name:
           type: string
-          description: id of PZEM sensor
+          description: The name of the PZEM sensor
           examples:
             - acInput
         voltageV:
@@ -345,13 +345,13 @@ components:
           examples:
             - 0.012914399
       required:
-        - id
+        - name
     PzemAddress:
       type: object
       properties:
-        id:
+        name:
           type: string
-          description: id of PZEM sensor
+          description: The name of the PZEM sensor
           examples:
             - acInput
         addressToSet:
@@ -366,15 +366,15 @@ components:
           type: boolean
           description: true/false indicator when the address is set
       required:
-        - id
+        - name
         - addressToSet
         - isChanged
     DcPzemShunt:
       type: object
       properties:
-        id:
+        name:
           type: string
-          description: id of PZEM sensor
+          description: The name of the PZEM sensor
           examples:
             - dcBattery
         shuntTypeToSet:
@@ -389,20 +389,20 @@ components:
           type: boolean
           description: true/false indicator when the shunt type is set
       required:
-        - id
+        - name
         - shuntTypeToSet
         - isChanged
     PzemCounter:
       type: object
       properties:
-        id:
+        name:
           type: string
-          description: id of PZEM sensor
+          description: The name of the PZEM sensor
           examples:
             - acInput
         isReset:
           type: boolean
           description: true/false indicators for every PZEM to notify which counters were reset
       required:
-        - id
+        - name
         - isReset

--- a/include/pzems/classes/acpzem.h
+++ b/include/pzems/classes/acpzem.h
@@ -9,7 +9,7 @@
 
 class AcPzem : public BasePzem {
  public:
-  AcPzem(String id, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress = PZEM_DEFAULT_ADDR);
+  AcPzem(String name, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress = PZEM_DEFAULT_ADDR);
 
   JsonDocument getStatus();
   JsonDocument getValues(const Date& date);

--- a/include/pzems/classes/basePzem.h
+++ b/include/pzems/classes/basePzem.h
@@ -15,12 +15,12 @@ struct Zone {
 
 class BasePzem {
  public:
-  BasePzem(String id, uint8_t storageAddress);
+  BasePzem(String name, uint8_t storageAddress);
 
   void startPzem();
 
  protected:
-  String _id;
+  String _name;
   Date _createdAt;
 
   float _voltage;

--- a/include/pzems/classes/dcpzem.h
+++ b/include/pzems/classes/dcpzem.h
@@ -9,7 +9,7 @@
 
 class DcPzem : public BasePzem {
  public:
-  DcPzem(String id, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress = PZEM017_DEFAULT_ADDR);
+  DcPzem(String name, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress = PZEM017_DEFAULT_ADDR);
 
   JsonDocument getStatus();
   JsonDocument getValues(const Date& date);

--- a/include/pzems/pzem.h
+++ b/include/pzems/pzem.h
@@ -6,9 +6,9 @@
 #include "classes/acpzem.h"
 #include "classes/dcpzem.h"
 
-#define AC_INPUT_PZEM_ID "acInput"
-#define AC_OUTPUT_PZEM_ID "acOutput"
-#define DC_BATTERY_PZEM_ID "dcBattery"
+#define AC_INPUT_PZEM_NAME "acInput"
+#define AC_OUTPUT_PZEM_NAME "acOutput"
+#define DC_BATTERY_PZEM_NAME "dcBattery"
 
 void startPzems();
 

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -65,13 +65,13 @@ void handlePzemValues() {
   server.send(HTTP_CODE_OK, F("application/json"), payload);
 }
 
-// PATCH "/pzems/address?id={id}&address={1}"
+// PATCH "/pzems/address?name={name}&address={1}"
 void handlePzemAddressChange() {
-  String id = server.arg(F("id"));
+  String name = server.arg(F("name"));
   long address = server.arg(F("address")).toInt();
 
-  if (id.isEmpty()) {
-    server.send(HTTP_CODE_BAD_REQUEST, F("text/plain"), F("The \"id\" param is required"));
+  if (name.isEmpty()) {
+    server.send(HTTP_CODE_BAD_REQUEST, F("text/plain"), F("The \"name\" param is required"));
 
     return;
   }
@@ -88,10 +88,10 @@ void handlePzemAddressChange() {
     return;
   }
 
-  JsonDocument doc = changePzemAddress(id, address);
+  JsonDocument doc = changePzemAddress(name, address);
 
   if (doc.isNull()) {
-    server.send(HTTP_CODE_NOT_FOUND, F("text/plain"), F("PZEM with entered \"id\" is not found"));
+    server.send(HTTP_CODE_NOT_FOUND, F("text/plain"), F("PZEM with entered name is not found"));
 
     return;
   }
@@ -103,13 +103,13 @@ void handlePzemAddressChange() {
   server.send(HTTP_CODE_OK, F("application/json"), payload);
 }
 
-// PATCH "/pzems/shunt?id={id}&shunt={1}"
+// PATCH "/pzems/shunt?name={name}&shunt={1}"
 void handlePzemShuntChange() {
-  String id = server.arg(F("id"));
+  String name = server.arg(F("name"));
   long shuntType = server.arg(F("shunt")).toInt();
 
-  if (id.isEmpty()) {
-    server.send(HTTP_CODE_BAD_REQUEST, F("text/plain"), F("The \"id\" param is required"));
+  if (name.isEmpty()) {
+    server.send(HTTP_CODE_BAD_REQUEST, F("text/plain"), F("The \"name\" param is required"));
 
     return;
   }
@@ -120,10 +120,10 @@ void handlePzemShuntChange() {
     return;
   }
 
-  JsonDocument doc = changePzemShuntType(id, shuntType);
+  JsonDocument doc = changePzemShuntType(name, shuntType);
 
   if (doc.isNull()) {
-    server.send(HTTP_CODE_NOT_FOUND, F("text/plain"), F("PZEM with entered \"id\" is not found"));
+    server.send(HTTP_CODE_NOT_FOUND, F("text/plain"), F("PZEM with entered name is not found"));
 
     return;
   }

--- a/src/pzems/classes/acpzem.cpp
+++ b/src/pzems/classes/acpzem.cpp
@@ -2,13 +2,13 @@
 
 // Public
 
-AcPzem::AcPzem(String id, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress)
-    : BasePzem(id, storageAddress), _pzem(port, pzemAddress) {}
+AcPzem::AcPzem(String name, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress)
+    : BasePzem(name, storageAddress), _pzem(port, pzemAddress) {}
 
 JsonDocument AcPzem::getStatus() {
   JsonDocument doc;
 
-  doc[F("id")] = _id;
+  doc[F("name")] = _name;
   doc[F("isConnected")] = isConnected();
   doc[F("currentAddress")] = _pzem.getAddress();
   doc[F("savedAddress")] = _pzem.readAddress();
@@ -56,7 +56,7 @@ JsonDocument AcPzem::getValues(const Date& date) {
   }
 
   if (!doc.isNull()) {
-    doc[F("id")] = _id;
+    doc[F("name")] = _name;
   }
 
   return doc;
@@ -65,7 +65,7 @@ JsonDocument AcPzem::getValues(const Date& date) {
 JsonDocument AcPzem::changeAddress(uint8_t addr) {
   JsonDocument doc;
 
-  doc[F("id")] = _id;
+  doc[F("name")] = _name;
   doc[F("addressToSet")] = addr;
   doc[F("isChanged")] = _pzem.setAddress(addr);
 
@@ -75,7 +75,7 @@ JsonDocument AcPzem::changeAddress(uint8_t addr) {
 JsonDocument AcPzem::resetCounter() {
   JsonDocument doc;
 
-  doc[F("id")] = _id;
+  doc[F("name")] = _name;
 
   if (!isConnected() || !isEepromConnected()) {
     doc[F("isReset")] = false;

--- a/src/pzems/classes/basePzem.cpp
+++ b/src/pzems/classes/basePzem.cpp
@@ -2,8 +2,8 @@
 
 // Public
 
-BasePzem::BasePzem(String id, uint8_t storageAddress)
-    : _id(id), _storageAddress(storageAddress) {}
+BasePzem::BasePzem(String name, uint8_t storageAddress)
+    : _name(name), _storageAddress(storageAddress) {}
 
 void BasePzem::startPzem() {
   _zone = getZone();

--- a/src/pzems/classes/dcpzem.cpp
+++ b/src/pzems/classes/dcpzem.cpp
@@ -2,13 +2,13 @@
 
 // Public
 
-DcPzem::DcPzem(String id, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress)
-    : BasePzem(id, storageAddress), _pzem(port, pzemAddress) {}
+DcPzem::DcPzem(String name, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress)
+    : BasePzem(name, storageAddress), _pzem(port, pzemAddress) {}
 
 JsonDocument DcPzem::getStatus() {
   JsonDocument doc;
 
-  doc[F("id")] = _id;
+  doc[F("name")] = _name;
   doc[F("isConnected")] = isConnected();
   doc[F("currentAddress")] = _pzem.getAddress();
   doc[F("savedAddress")] = _pzem.getHoldingAddress();
@@ -49,7 +49,7 @@ JsonDocument DcPzem::getValues(const Date& date) {
   }
 
   if (!doc.isNull()) {
-    doc[F("id")] = _id;
+    doc[F("name")] = _name;
   }
 
   return doc;
@@ -58,7 +58,7 @@ JsonDocument DcPzem::getValues(const Date& date) {
 JsonDocument DcPzem::changeAddress(uint8_t addr) {
   JsonDocument doc;
 
-  doc[F("id")] = _id;
+  doc[F("name")] = _name;
   doc[F("addressToSet")] = addr;
   doc[F("isChanged")] = _pzem.setAddress(addr);
 
@@ -68,7 +68,7 @@ JsonDocument DcPzem::changeAddress(uint8_t addr) {
 JsonDocument DcPzem::changeShuntType(uint16_t type) {
   JsonDocument doc;
 
-  doc[F("id")] = _id;
+  doc[F("name")] = _name;
   doc[F("shuntTypeToSet")] = type;
   doc[F("isChanged")] = _pzem.setShuntType(type);
 
@@ -78,7 +78,7 @@ JsonDocument DcPzem::changeShuntType(uint16_t type) {
 JsonDocument DcPzem::resetCounter() {
   JsonDocument doc;
 
-  doc[F("id")] = _id;
+  doc[F("name")] = _name;
 
   if (!isConnected() || !isEepromConnected()) {
     doc[F("isReset")] = false;

--- a/src/pzems/pzem.cpp
+++ b/src/pzems/pzem.cpp
@@ -3,10 +3,10 @@
 static SoftwareSerial acPzemSerial(AC_PZEM_RX_PIN, AC_PZEM_TX_PIN);
 static SoftwareSerial dcBatteryPzemSerial(DC_BATTERY_PZEM_RX_PIN, DC_BATTERY_PZEM_TX_PIN);
 
-static AcPzem acInputPzem(AC_INPUT_PZEM_ID, acPzemSerial, 0, AC_INPUT_PZEM_ADDRESS);
-static AcPzem acOutputPzem(AC_OUTPUT_PZEM_ID, acPzemSerial, 16, AC_OUTPUT_PZEM_ADDRESS);
+static AcPzem acInputPzem(AC_INPUT_PZEM_NAME, acPzemSerial, 0, AC_INPUT_PZEM_ADDRESS);
+static AcPzem acOutputPzem(AC_OUTPUT_PZEM_NAME, acPzemSerial, 16, AC_OUTPUT_PZEM_ADDRESS);
 
-static DcPzem dcBatteryPzem(DC_BATTERY_PZEM_ID, dcBatteryPzemSerial, 32, DC_BATTERY_PZEM_ADDRESS);
+static DcPzem dcBatteryPzem(DC_BATTERY_PZEM_NAME, dcBatteryPzemSerial, 32, DC_BATTERY_PZEM_ADDRESS);
 
 void startPzems() {
   Serial.println(F("Initializing PZEM zones"));
@@ -64,24 +64,24 @@ JsonDocument resetPzemsCounter() {
   return doc;
 }
 
-JsonDocument changePzemAddress(String pzemId, uint8_t address) {
+JsonDocument changePzemAddress(String name, uint8_t address) {
   JsonDocument doc;
 
-  if (pzemId == F(AC_INPUT_PZEM_ID)) {
+  if (name == F(AC_INPUT_PZEM_NAME)) {
     doc = acInputPzem.changeAddress(address);
-  } else if (pzemId == F(AC_OUTPUT_PZEM_ID)) {
+  } else if (name == F(AC_OUTPUT_PZEM_NAME)) {
     doc = acOutputPzem.changeAddress(address);
-  } else if (pzemId == F(DC_BATTERY_PZEM_ID)) {
+  } else if (name == F(DC_BATTERY_PZEM_NAME)) {
     doc = dcBatteryPzem.changeAddress(address);
   }
 
   return doc;
 }
 
-JsonDocument changePzemShuntType(String pzemId, uint8_t shuntType) {
+JsonDocument changePzemShuntType(String name, uint8_t shuntType) {
   JsonDocument doc;
 
-  if (pzemId == F(DC_BATTERY_PZEM_ID)) {
+  if (name == F(DC_BATTERY_PZEM_NAME)) {
     doc = dcBatteryPzem.changeShuntType(shuntType);
   }
 


### PR DESCRIPTION
## Description

## After

<img width="631" alt="image" src="https://github.com/user-attachments/assets/df77af9a-035c-48d4-9234-463d8a6eaf42" />
