### PR TITLE
SC-63: Slow ESP IP resolution during HTTP requests

### DIFF
--- a/include/http/server.h
+++ b/include/http/server.h
@@ -5,7 +5,6 @@
 #include <Arduino.h>
 #include <ESP8266HTTPClient.h>
 #include <ESP8266WebServer.h>
-#include <ESP8266mDNS.h>
 #include "pzems/pzem.h"
 #include "utils/wifi.h"
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,6 @@ build_flags =
 	'-D WIFI_SSID=${secrets.wifi_ssid}'
 	'-D WIFI_PWD=${secrets.wifi_pwd}'
 	'-D DEBUG_MODE=${secrets.debug_mode}'
-	'-D ESP_DOMAIN_NAME=${secrets.esp_domain_name}'
 	'-D BROADCAST_INTERVAL=${secrets.broadcast_interval}'
 	'-D AC_PZEM_RX_PIN=${secrets.ac_pzem_rx_pin}'
 	'-D AC_PZEM_TX_PIN=${secrets.ac_pzem_tx_pin}'

--- a/secrets-example.ini
+++ b/secrets-example.ini
@@ -6,9 +6,6 @@ wifi_pwd=""
 ; ESP
 debug_mode=0 ; Disable for prod firmware to improve the performance
 
-; DNS
-esp_domain_name="esp8266"
-
 ; Websocket
 broadcast_interval=1000
 

--- a/src/http/server.cpp
+++ b/src/http/server.cpp
@@ -3,25 +3,18 @@
 static ESP8266WebServer server(80);
 
 void startServer() {
-  if (MDNS.begin(ESP_DOMAIN_NAME)) {
-    Serial.println(F("MDNS responder started"));
-  }
-
   configRouter();
 
   server.enableCORS(true);
   server.begin();
 
   Serial.println(F("HTTP server started on:"));
-  Serial.print(F("1. IP address: http://"));
+  Serial.print(F("http://"));
   Serial.println(WiFi.localIP());
-  Serial.print(F("2. URL: "));
-  Serial.println(F("http://" ESP_DOMAIN_NAME ".local"));
 }
 
 void tickServer() {
   server.handleClient();
-  MDNS.update();
 }
 
 void configRouter() {

--- a/src/utils/wifi.cpp
+++ b/src/utils/wifi.cpp
@@ -1,10 +1,20 @@
 #include "utils/wifi.h"
 
+static IPAddress ip(192, 168, 50, 190);     // Static IP Address
+static IPAddress gateway(192, 168, 50, 1);  // Gateway IP Address (router)
+static IPAddress subnet(255, 255, 255, 0);
+
 void connectToWiFi() {
   Serial.print(F("Connecting to "));
-  Serial.print(WIFI_SSID);
+  Serial.println(WIFI_SSID);
 
   WiFi.mode(WIFI_STA);
+
+  bool isConfigured = WiFi.config(ip, gateway, subnet);
+
+  Serial.print(F("ESP Static IP: "));
+  Serial.println(isConfigured ? F("Configured") : F("Configuration Failed"));
+
   WiFi.begin(WIFI_SSID, WIFI_PWD);
 
   while (WiFi.status() != WL_CONNECTED) {

--- a/src/websocket/websocket.cpp
+++ b/src/websocket/websocket.cpp
@@ -6,11 +6,9 @@ void startWebSocket() {
   webSocket.begin();
 
   Serial.println(F("WebSocket started on:"));
-  Serial.print(F("1. IP address: ws://"));
+  Serial.print(F("ws://"));
   Serial.print(WiFi.localIP());
   Serial.println(F(":81"));
-  Serial.print(F("2. URL: "));
-  Serial.println(F("ws://" ESP_DOMAIN_NAME ".local:81"));
 }
 
 void tickWebSocket() {


### PR DESCRIPTION
## Description

- The mDNS library resolves the ESP IP address rather slowly (5-8 seconds). The probable cause was not found. To address the issue, mDNS was migrated to a static IP configuration.
