### PR TITLE
SC-99: Calculate full energy instead of active

### DIFF
--- a/.changeset/light-steaks-argue.md
+++ b/.changeset/light-steaks-argue.md
@@ -1,0 +1,5 @@
+---
+"solar-control-arduino": minor
+---
+
+SC-99: Calculate full energy instead of active

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -259,14 +259,9 @@ components:
           maximum: 248
           examples:
             - 2
-        savedShuntType:
-          type: integer
-          format: int32
-          description: Shunt type saved in PZEM memory
-          minimum: 0
-          maximum: 3
-          examples:
-            - 1
+        isFullPower:
+          type: boolean
+          description: true/false indicator to include reactive power param into calculation
       required:
         - name
         - isConnected
@@ -304,31 +299,31 @@ components:
           description: The name of the sensor
           examples:
             - acInput
-        voltageV:
+        voltage:
           type: number
           format: float
           description: AC/DC voltage in Volts
           examples:
             - 233.1000061
-        currentA:
+        current:
           type: number
           format: float
           description: AC/DC current in Amps
           examples:
             - 0.097999997
-        powerKw:
+        power:
           type: number
           format: float
           description: AC/DC active power in kW
           examples:
             - 0.0135
-        energyKwh:
+        energy:
           type: number
           format: float
           description: AC/DC active energy in kWh since last reset
           examples:
             - 0.003
-        frequencyHz:
+        frequency:
           type: number
           format: float
           description: AC frequency in Hz
@@ -340,13 +335,13 @@ components:
           description: AC power factor of the load
           examples:
             - 0.589999974
-        t1EnergyKwh:
+        t1Energy:
           type: number
           format: float
           description: Calculated value of active energy during T1 zone
           examples:
             - 0.004999999
-        t2EnergyKwh:
+        t2Energy:
           type: number
           format: float
           description: Calculated value of active energy during T2 zone

--- a/include/sensors/classes/acPzem.h
+++ b/include/sensors/classes/acPzem.h
@@ -18,7 +18,7 @@ struct Zone {
 
 class AcPzem : public BasePzem {
  public:
-  AcPzem(String name, SoftwareSerial& port, uint8_t storageAddress, uint8_t pzemAddress = PZEM_DEFAULT_ADDR);
+  AcPzem(String name, SoftwareSerial& port, uint8_t storageAddress, bool isFullPower, uint8_t pzemAddress = PZEM_DEFAULT_ADDR);
 
   void startPzem();
 
@@ -34,6 +34,7 @@ class AcPzem : public BasePzem {
   Zone _zone;
 
   uint8_t _storageAddress;
+  bool _isFullPower;
 
   float _t1Energy;
   float _t2Energy;
@@ -42,6 +43,7 @@ class AcPzem : public BasePzem {
 
   bool isConnected();
   void readValues();
+  float calcFullPower(float value);
   void calcZoneEnergy();
   void clearZone();
 

--- a/src/sensors/classes/dcDivider.cpp
+++ b/src/sensors/classes/dcDivider.cpp
@@ -13,7 +13,7 @@ void DcDivider::start() {
 JsonDocument DcDivider::getValues() {
   JsonDocument doc;
 
-  doc[F("voltageV")] = getVoltage();
+  doc[F("voltage")] = getVoltage();
   doc[F("name")] = _name;
 
   return doc;

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -2,8 +2,8 @@
 
 static SoftwareSerial acPzemSerial(AC_PZEM_RX_PIN, AC_PZEM_TX_PIN);
 
-static AcPzem acInputPzem(AC_INPUT_SENSOR_NAME, acPzemSerial, 0, AC_INPUT_PZEM_ADDRESS);
-static AcPzem acOutputPzem(AC_OUTPUT_SENSOR_NAME, acPzemSerial, 16, AC_OUTPUT_PZEM_ADDRESS);
+static AcPzem acInputPzem(AC_INPUT_SENSOR_NAME, acPzemSerial, 0, true, AC_INPUT_PZEM_ADDRESS);
+static AcPzem acOutputPzem(AC_OUTPUT_SENSOR_NAME, acPzemSerial, 16, false, AC_OUTPUT_PZEM_ADDRESS);
 static DcDivider dcDivider(DC_BATTERY_SENSOR_NAME);
 
 void startSensors() {


### PR DESCRIPTION
## Description

- Only for Input PZEM calculate full power parameters based on active power params measured by PZEM sensor

## After
![image](https://github.com/user-attachments/assets/c319e292-fb82-4092-8b5b-26459f2fc109)

![Screenshot 2025-02-01 at 3 54 04 PM](https://github.com/user-attachments/assets/8781c931-1f47-4953-9e70-78ada4d74f19)

