### PR TITLE
SC-115: Do not rewrite protection rule when it is equal with passed DTO

### DIFF
--- a/.changeset/great-rabbits-camp.md
+++ b/.changeset/great-rabbits-camp.md
@@ -1,0 +1,5 @@
+---
+"solar-control-arduino": patch
+---
+
+SC-115: Do not rewrite protection rule when it is equal with passed DTO

--- a/include/sensors/protection-rule.h
+++ b/include/sensors/protection-rule.h
@@ -29,12 +29,14 @@ enum ProtectionRuleSaveState {
   SAVE_STATE_SUCCESS,
   SAVE_STATE_ERROR,
   SAVE_STATE_NOT_FOUND,
+  SAVE_STATE_NOT_MODIFIED,
 };
 
 void loadProtectionRules();
 JsonDocument getProtectionRules();
 
-ProtectionRuleSaveState saveProtectionRule(const JsonDocument& data);
+ProtectionRuleSaveState saveProtectionRule(const JsonDocument& doc);
+bool isEqual(const ProtectionRule& rule, const JsonDocument& doc);
 ProtectionRule updateProtectionRule(const JsonDocument& doc);
 ProtectionRuleSaveState storeProtectionRules();
 

--- a/src/sensors/protection-rule.cpp
+++ b/src/sensors/protection-rule.cpp
@@ -31,20 +31,36 @@ ProtectionRuleSaveState saveProtectionRule(const JsonDocument& doc) {
   String id = doc[F("id")];
 
   if (id == AC_OUTPUT_FREQUENCY_RULE) {
+    if (isEqual(config.acOutputFrequency, doc)) {
+      return SAVE_STATE_NOT_MODIFIED;
+    }
+
     config.acOutputFrequency = updateProtectionRule(doc);
 
     return storeProtectionRules();
   } else if (id == AC_OUTPUT_VOLTAGE_RULE) {
+    if (isEqual(config.acOutputVoltage, doc)) {
+      return SAVE_STATE_NOT_MODIFIED;
+    }
+
     config.acOutputVoltage = updateProtectionRule(doc);
 
     return storeProtectionRules();
   } else if (id == DC_BATTERY_VOLTAGE_RULE) {
+    if (isEqual(config.dcBatteryVoltage, doc)) {
+      return SAVE_STATE_NOT_MODIFIED;
+    }
+
     config.dcBatteryVoltage = updateProtectionRule(doc);
 
     return storeProtectionRules();
   }
 
   return SAVE_STATE_NOT_FOUND;
+}
+
+bool isEqual(const ProtectionRule& rule, const JsonDocument& doc) {
+  return rule.min == doc[F("min")] && rule.max == doc[F("max")];
 }
 
 ProtectionRule updateProtectionRule(const JsonDocument& doc) {


### PR DESCRIPTION
## Description

- To reduce EEPROM exhausting do not rewrite rules config when DTO is equal with edited rule

